### PR TITLE
Added exact match filtering helpers

### DIFF
--- a/mist-api/src/routes/genomes/get.js
+++ b/mist-api/src/routes/genomes/get.js
@@ -11,7 +11,10 @@ module.exports = function(app, middlewares, routeMiddlewares) {
 				models.Component
 			],
 			maxPage: null,
-			permittedOrderFields: '*'
+			permittedOrderFields: '*',
+			permittedWhereFields: [
+				'taxonomy_id',
+			],
 		}),
 		helper.findManyHandler()
 	]


### PR DESCRIPTION
## Work done
This PR extends the Criteria service with the ability to apply simple filtering when searching for record(s). Only those fields labeled as `permittedWhereFields` are allowed to be searched against by external queries.

To add simple filtering to a route, define the set of fields that may be queried to the options for `parseCriteriaForMany`. For example,

```
// GET /genomes route
		middlewares.parseCriteriaForMany(models.Genome, {
			permittedWhereFields: [
				'taxonomy_id',
			],
		}),
```

makes it possible to query for matches to the `taxonomy_id`. Examples of API queries are:

Search for a single taxonomy_id:
GET `/genomes?where.taxonomy_id=2162`

Search for multiple taxonomy_ids:
GET `/genomes?where.taxonomy_id=2162,1204725,93423`

#### QA Setup
Load some genomes into a test database.

#### Tests
- [ ] GET by a single taxonomy_id returns the expected result
- [ ] GET for multiple taxonomy_ids returns the expected result
- [ ] GET for a non-existent taxonomy_id does not return any results
