### PR TITLE
Ability to search for genomes by name

### DIFF
--- a/core-lib/src/util.js
+++ b/core-lib/src/util.js
@@ -1,0 +1,32 @@
+'use strict'
+
+/**
+ * Splits ${value} into terms that are separated by whitespace and preserving
+ * simple quoted groups of words (only double quotes - does not handle nested
+ * quotes).
+ *
+ * All non-string values except null and undefined are converted to
+ * a string value. Order of matches is not guaranteed to match input
+ * order.
+ *
+ * @param {String} value
+ * @returns {Array.<String>}
+ */
+exports.splitIntoTerms = (value) => {
+  const result = []
+  if (value === undefined || value === null)
+    return result
+
+  value += '' // Convert to string
+
+  const quotedTerms = []
+  const valueWithoutQuotedTerms = value.replace(/"([^"]*)"/g, (match, quotedWord) => {
+    quotedTerms.push(quotedWord)
+    return ''
+  })
+
+  return valueWithoutQuotedTerms.split(/\s+/)
+    .concat(quotedTerms)
+    .map((word) => word.replace(/[^\w .]/g, '').trim()) // Allow word characters, spaces, and periods
+    .filter((word) => !!word)
+}

--- a/core-lib/src/util.tests.js
+++ b/core-lib/src/util.tests.js
@@ -1,0 +1,102 @@
+'use strict'
+
+// Local
+const util = require('./util')
+
+describe('util', () => {
+  describe('splitIntoTerms', () => {
+    const examples = [
+      {
+        value: undefined,
+        expect: [],
+      },
+      {
+        value: null,
+        expect: [],
+      },
+      {
+        value: false,
+        expect: ['false'],
+      },
+      {
+        value: 0,
+        expect: ['0'],
+      },
+      {
+        value: 1,
+        expect: ['1'],
+      },
+      {
+        value: '',
+        expect: [],
+      },
+      {
+        value: ' ',
+        expect: [],
+      },
+      {
+        value: '\t \v \n \r',
+        expect: [],
+      },
+      {
+        value: '""',
+        expect: [],
+      },
+      {
+        value: ' " " ',
+        expect: [],
+      },
+      {
+        value: '\'',
+        expect: [],
+      },
+      {
+        value: 'protein',
+        expect: ['protein'],
+      },
+      {
+        value: ' protein ',
+        expect: ['protein'],
+      },
+      {
+        value: 'protein',
+        expect: ['protein'],
+      },
+      {
+        value: 'protein protein',
+        expect: ['protein', 'protein'],
+      },
+      {
+        value: 'alpha  dismutase',
+        expect: ['alpha', 'dismutase'],
+      },
+      {
+        value: '"alpha dismutase"',
+        expect: ['alpha dismutase'],
+      },
+      {
+        value: 'beta "alpha dismutase" barrel',
+        expect: ['beta', 'alpha dismutase', 'barrel'],
+      },
+      {
+        value: '"alpha dismutase',
+        expect: ['alpha', 'dismutase'],
+      },
+      {
+        value: '"alpha dismutase" "beta barrel"',
+        expect: ['alpha dismutase', 'beta barrel'],
+      },
+      {
+        value: '\'al\'pha\'',
+        expect: ['alpha'],
+      },
+    ]
+
+    examples.forEach((example) => {
+      it(`${example.value} -> ${JSON.stringify(example.expect)}`, () => {
+        let result = util.splitIntoTerms(example.value)
+        expect(result).members(example.expect)
+      })
+    })
+  })
+})

--- a/mist-api/src/routes/genomes/get.js
+++ b/mist-api/src/routes/genomes/get.js
@@ -1,5 +1,11 @@
 'use strict'
 
+// Vendor
+const _ = require('lodash')
+
+// Local
+const util = require('core-lib/util')
+
 module.exports = function(app, middlewares, routeMiddlewares) {
 	let models = app.get('models'),
 		helper = app.get('lib').RouteHelper.for(models.Genome)
@@ -16,6 +22,16 @@ module.exports = function(app, middlewares, routeMiddlewares) {
 				'taxonomy_id',
 			],
 		}),
+		// Provide for searching against name
+		(req, res, next) => {
+			if (Reflect.has(req.query, 'search')) {
+				const searchTerms = util.splitIntoTerms(req.query.search)
+					.map((term) => `%${term}%`)
+				if (searchTerms.length > 0)
+					_.set(res.locals, 'criteria.where.name.$iLike.$any', searchTerms)
+			}
+			next()
+		},
 		helper.findManyHandler()
 	]
 }


### PR DESCRIPTION
### Work done
Motivation: A frequently desirable capability is the ability to search for matches to free-form text without knowledge of the underlying data structure (e.g. google).

This PR adds a helper function to provide basic term splitting from an input string and the ability to query for genomes with names that match a set of input terms.

GET /genomes?search=coli
GET /genomes?search="Escherichia coli" MG1673

### Tests
- [x] Empty search value returns all genomes
- [x] Search term with surrounding whitespace ignores the extra whitespace
- [x] Search term that does not match any records returns empty array
- [x] Search term that matches one record exactly
- [x] Search term that matches multiple records
- [x] Multiple search terms