### PR TITLE
added algorithm for finding neighboring indices

### DIFF
--- a/core-lib/src/array-util.js
+++ b/core-lib/src/array-util.js
@@ -6,7 +6,7 @@
  * @returns {Array} - elements in ${a} that are not in ${b}
  */
 exports.difference = (a, b) => {
-	let bSet = new Set(b)
+	const bSet = new Set(b)
 	return a.filter((x) => !bSet.has(x))
 }
 
@@ -17,3 +17,27 @@ exports.difference = (a, b) => {
 exports.flatten = (array) => array.reduce((a, b) => {
 	return a.concat(Array.isArray(b) ? exports.flatten(b) : b)
 }, [])
+
+/**
+ * @param {Array.<Object>} arrayOfObjects
+ * @param {string} [key = 'id']
+ * @returns {Object} objects indexed by ${key} field of each object
+ */
+exports.indexObjects = (arrayOfObjects, key = 'id') => arrayOfObjects.reduce(
+	(result, object) => {
+		result[object[key]] = object
+		return result
+	},
+	{}
+)
+
+/**
+ * @param {Array.<Object>} arrayOfObjects
+ * @param {Array.<number|string>} orderedValues
+ * @param {string} [key = 'id']
+ * @returns {Array.<Object>} ${arrayOfObjects} in the order of ${orderedValues} where each value of orderedValues corresponds to the key value of each object in arrayOfObjects
+ */
+exports.sortBy = (arrayOfObjects, orderedValues, key = 'id') => {
+	const objectsByKey = exports.indexObjects(arrayOfObjects, key)
+	return orderedValues.map((value) => objectsByKey[value])
+}

--- a/core-lib/src/array-util.tests.js
+++ b/core-lib/src/array-util.tests.js
@@ -7,15 +7,15 @@ const arrayUtil = require('./array-util')
 describe('array-util', function() {
 	describe('difference', function() {
 		it('two empty arrays returns a new empty array', function() {
-			let a = [],
-				b = [],
-				c = arrayUtil.difference(a, b)
+			const a = []
+			const b = []
+			const c = arrayUtil.difference(a, b)
 			expect(a).not.equal(c)
 			expect(b).not.equal(c)
 			expect(c).eql([])
 		})
 
-		let examples = [
+		const examples = [
 			{
 				a: [1],
 				b: [],
@@ -50,7 +50,7 @@ describe('array-util', function() {
 
 		examples.forEach((example) => {
 			it(`${JSON.stringify(example.a)} difference ${JSON.stringify(example.b)} -> ${JSON.stringify(example.expect)}`, function() {
-				let result = arrayUtil.difference(example.a, example.b)
+				const result = arrayUtil.difference(example.a, example.b)
 				expect(result).eql(example.expect)
 			})
 		})
@@ -58,13 +58,13 @@ describe('array-util', function() {
 
 	describe('flatten', function() {
 		it('empty array returns new empty array', function() {
-			let a = [],
-				result = arrayUtil.flatten(a)
+			const a = []
+			const result = arrayUtil.flatten(a)
 			expect(result).not.equal(a)
 			expect(result).eql([])
 		})
 
-		let examples = [
+		const examples = [
 			{
 				a: [1, 2],
 				expect: [1, 2]
@@ -85,9 +85,55 @@ describe('array-util', function() {
 
 		examples.forEach((example) => {
 			it(`${JSON.stringify(example.a)} -> ${JSON.stringify(example.expect)}`, function() {
-				let result = arrayUtil.flatten(example.a)
+				const result = arrayUtil.flatten(example.a)
 				expect(result).eql(example.expect)
 			})
+		})
+	})
+
+	describe('indexObject', function() {
+		it('indexes objects using default key of id', () => {
+			const objects = [
+				{id: 1, name: 'alpha'},
+				{id: 2, name: 'beta'},
+				{id: 3, name: 'gamma'},
+			]
+			expect(arrayUtil.indexObjects(objects)).eql({
+				1: objects[0],
+				2: objects[1],
+				3: objects[2],
+			})
+		})
+
+		it('indexes objects using alternate key', () => {
+			const objects = [
+				{id: 1, name: 'alpha'},
+				{id: 2, name: 'beta'},
+				{id: 3, name: 'gamma'},
+			]
+			expect(arrayUtil.indexObjects(objects, 'name')).eql({
+				alpha: objects[0],
+				beta: objects[1],
+				gamma: objects[2],
+			})
+		})
+	})
+
+	describe('sortBy', function() {
+		it('should sort objects using id field of order', () => {
+			const objects = [
+				{id: 1, name: 'alpha'},
+				{id: 2, name: 'beta'},
+				{id: 3, name: 'gamma'},
+			]
+			const order = [2, 1, 3]
+			const correct = [
+				{id: 2, name: 'beta'},
+				{id: 1, name: 'alpha'},
+				{id: 3, name: 'gamma'},
+			]
+
+			expect(arrayUtil.sortBy(objects, order)).eql(correct)
 		})
 	})
 })

--- a/core-lib/src/util.js
+++ b/core-lib/src/util.js
@@ -25,9 +25,9 @@ exports.findNeighoringIndices = (index, rangeStart, rangeStop, isCircular, optio
   assert(index <= rangeStop, 'index must be less than or equal to rangeStop')
 
   options = options || {}
-  const amount = Reflect.has(options, 'amount') ? options.amount : kDefaultNeighborAmount
-  let amountBefore = Reflect.has(options, 'amountBefore') ? options.amountBefore : amount
-  let amountAfter = Reflect.has(options, 'amountAfter') ? options.amountAfter : amount
+  const amount = options.amount !== undefined ? options.amount : kDefaultNeighborAmount
+  let amountBefore = options.amountBefore !== undefined ? options.amountBefore : amount
+  let amountAfter = options.amountAfter !== undefined ? options.amountAfter : amount
   assert(amountBefore >= 0, 'options.amountBefore must be greater than or equal to 0')
   assert(amountAfter >= 0, 'options.amountAfter must be greater than or equal to 0')
 

--- a/core-lib/src/util.js
+++ b/core-lib/src/util.js
@@ -1,5 +1,81 @@
 'use strict'
 
+// Core
+const assert = require('assert')
+
+// Constants
+const kDefaultNeighborAmount = 5
+
+/**
+ * @param {number} index 1-based, integral position of an entity
+ * @param {number} rangeStart 1-based, integer start of range containing index (inclusive)
+ * @param {number} rangeStop 1-based, integer stop of range containing index (inclusive)
+ * @param {boolean} isCircular true if ${rangeStart}..${rangeStop} is circular and continuous
+ * @param {object?} [options = {}]
+ * @param {number?} [options.amount = 5] default number of indices to include in both directions relative to ${index}
+ * @param {number?} [options.amountBefore = options.amount] number of indices to include that occur before ${index}
+ * @param {number?} [options.amountAfter = options.amount] number of indices to include that occur after ${index}
+ * @returns {Array.<Array.<number,number>...>} array of 2-tuple 1-based ranges that are neighbors of ${index} and within ${rangeStart}..${rangeStop}; ordered by first value of each tuple
+ */
+exports.findNeighoringIndices = (index, rangeStart, rangeStop, isCircular, options) => {
+  assert(index > 0, 'index must be positive')
+  assert(rangeStart > 0, 'rangeStart must be positive')
+  assert(rangeStop >= rangeStart, 'rangeStop must be greater than or equal to rangeStart')
+  assert(index >= rangeStart, 'index must be greater than or equal to rangeStart')
+  assert(index <= rangeStop, 'index must be less than or equal to rangeStop')
+
+  options = options || {}
+  const amount = Reflect.has(options, 'amount') ? options.amount : kDefaultNeighborAmount
+  let amountBefore = Reflect.has(options, 'amountBefore') ? options.amountBefore : amount
+  let amountAfter = Reflect.has(options, 'amountAfter') ? options.amountAfter : amount
+  assert(amountBefore >= 0, 'options.amountBefore must be greater than or equal to 0')
+  assert(amountAfter >= 0, 'options.amountAfter must be greater than or equal to 0')
+
+  let lowestIndex = index
+  let effectiveRangeStop = rangeStop
+  const result = []
+  if (amountBefore > 0) {
+    if (index > rangeStart) {
+      const before = Math.max(rangeStart, index - amountBefore);
+      const indexRange = [before, index - 1]
+      result.push(indexRange)
+      const numInRange = indexRange[1] - indexRange[0] + 1
+      amountBefore -= numInRange
+
+      // This is needed when considering circular topologies for the amount after
+      lowestIndex = before
+    }
+
+    // Get any additional ones by wrapping around
+    if (isCircular && amountBefore > 0) {
+      const before = Math.max(index + 1, rangeStop - amountBefore + 1)
+      if (before <= rangeStop) {
+        result.push([before, rangeStop])
+        effectiveRangeStop = before - 1
+      }
+    }
+  }
+
+  if (amountAfter > 0) {
+    if (index < effectiveRangeStop) {
+      const after = Math.min(index + amountAfter, effectiveRangeStop)
+      const indexRange = [index + 1, after]
+      result.push(indexRange)
+      const numInRange = indexRange[1] - indexRange[0] + 1
+      amountAfter -= numInRange
+    }
+
+    // Get any additional ones by wrapping around
+    if (isCircular && amountAfter > 0 && lowestIndex > rangeStart) {
+      const after = Math.min(rangeStart + amountAfter, lowestIndex - 1)
+      const indexRange = [rangeStart, after]
+      result.push(indexRange)
+    }
+  }
+
+  return result
+}
+
 /**
  * Splits ${value} into terms that are separated by whitespace and preserving
  * simple quoted groups of words (only double quotes - does not handle nested

--- a/core-lib/src/util.js
+++ b/core-lib/src/util.js
@@ -15,7 +15,7 @@ const kDefaultNeighborAmount = 5
  * @param {number?} [options.amount = 5] default number of indices to include in both directions relative to ${index}
  * @param {number?} [options.amountBefore = options.amount] number of indices to include that occur before ${index}
  * @param {number?} [options.amountAfter = options.amount] number of indices to include that occur after ${index}
- * @returns {Array.<Array.<number,number>...>} array of 2-tuple 1-based ranges that are neighbors of ${index} and within ${rangeStart}..${rangeStop}; ordered by first value of each tuple
+ * @returns {Array.<Array.<number,number>...>} array of 2-tuple 1-based ranges that are neighbors of ${index} and within ${rangeStart}..${rangeStop}; ordered relative to indices before ${index} (taking into account circular indices)
  */
 exports.findNeighoringIndices = (index, rangeStart, rangeStop, isCircular, options) => {
   assert(index > 0, 'index must be positive')
@@ -50,7 +50,7 @@ exports.findNeighoringIndices = (index, rangeStart, rangeStop, isCircular, optio
     if (isCircular && amountBefore > 0) {
       const before = Math.max(index + 1, rangeStop - amountBefore + 1)
       if (before <= rangeStop) {
-        result.push([before, rangeStop])
+        result.unshift([before, rangeStop])
         effectiveRangeStop = before - 1
       }
     }

--- a/core-lib/src/util.tests.js
+++ b/core-lib/src/util.tests.js
@@ -4,6 +4,109 @@
 const util = require('./util')
 
 describe('util', () => {
+  describe('findNeighoringIndices', () => {
+    const examples = [
+      {
+        index: 1,
+        rangeStart: 1,
+        rangeStop: 1,
+        isCircular: false,
+        options: {amount: 1},
+        expect: [],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: false,
+        options: {amount: 0},
+        expect: [],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: false,
+        options: {amount: 1},
+        expect: [[1, 1], [3, 3]],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: false,
+        options: {amountBefore: 1, amountAfter: 0},
+        expect: [[1, 1]],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: false,
+        options: {amountBefore: 0, amountAfter: 1},
+        expect: [[3, 3]],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: false,
+        options: {amount: 5},
+        expect: [[1, 1], [3, 3]],
+      },
+      {
+        index: 200,
+        rangeStart: 150,
+        rangeStop: 201,
+        isCircular: false,
+        options: {amount: 5},
+        expect: [[195, 199], [201, 201]],
+      },
+
+      // Circular
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: true,
+        options: {amount: 1},
+        expect: [[1, 1], [3, 3]],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: true,
+        options: {amountBefore: 2, amountAfter: 0},
+        expect: [[1, 1], [3, 3]],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: true,
+        options: {amountBefore: 0, amountAfter: 2},
+        expect: [[3, 3], [1, 1]],
+      },
+      {
+        index: 200,
+        rangeStart: 150,
+        rangeStop: 201,
+        isCircular: true,
+        options: {amount: 5},
+        expect: [[195, 199], [201, 201], [150, 154]],
+      },
+    ]
+
+    examples.forEach((example) => {
+      const {index, rangeStart, rangeStop, isCircular, options} = example
+      it(`index ${index} of [${rangeStart}..${rangeStop}], circular: ${isCircular}, options: ${JSON.stringify(options)} should return ${JSON.stringify(example.expect)}`, () => {
+        const result = util.findNeighoringIndices(index, rangeStart, rangeStop, isCircular, options)
+        expect(result).eql(example.expect)
+      })
+    })
+  })
+
   describe('splitIntoTerms', () => {
     const examples = [
       {

--- a/core-lib/src/util.tests.js
+++ b/core-lib/src/util.tests.js
@@ -55,6 +55,18 @@ describe('util', () => {
         expect: [[1, 1], [3, 3]],
       },
       {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 3,
+        isCircular: false,
+        options: {
+          amount: undefined,
+          amountBefore: undefined,
+          amountAfter: undefined,
+        },
+        expect: [[1, 1], [3, 3]],
+      },
+      {
         index: 200,
         rangeStart: 150,
         rangeStop: 201,

--- a/core-lib/src/util.tests.js
+++ b/core-lib/src/util.tests.js
@@ -90,7 +90,7 @@ describe('util', () => {
         rangeStop: 3,
         isCircular: true,
         options: {amountBefore: 2, amountAfter: 0},
-        expect: [[1, 1], [3, 3]],
+        expect: [[3, 3], [1, 1]],
       },
       {
         index: 2,
@@ -107,6 +107,14 @@ describe('util', () => {
         isCircular: true,
         options: {amount: 5},
         expect: [[195, 199], [201, 201], [150, 154]],
+      },
+      {
+        index: 2,
+        rangeStart: 1,
+        rangeStop: 10,
+        isCircular: true,
+        options: {amount: 3},
+        expect: [[9, 10], [1, 1], [3, 5]],
       },
     ]
 

--- a/mist-api/package.json
+++ b/mist-api/package.json
@@ -72,6 +72,7 @@
     "split": "^1.0.0",
     "through2": "^2.0.1",
     "universal-analytics": "^0.4.2",
+    "validator": "^9.2.0",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
@@ -85,7 +86,7 @@
     "node-mocks-http": "^1.5.4",
     "pm2": "^2.6.1",
     "pre-commit": "^1.1.3",
-    "sinon": "^1.17.5",
+    "sinon": "^4.1.3",
     "supertest": "^2.0.0",
     "supertest-as-promised": "2.x",
     "temp": "^0.8.3"

--- a/mist-api/src/app.js
+++ b/mist-api/src/app.js
@@ -121,6 +121,10 @@ bootService.setup()
 	else
 		app.use(router)
 
+	// For the time being, ignore all favicon requests
+	app.get('/favicon.ico', (req, res) => {
+		res.status(204)
+	})
 	app.use('/', latestDocs())
 
 	app.use(errorHandler(app))

--- a/mist-api/src/middlewares/exists.js
+++ b/mist-api/src/middlewares/exists.js
@@ -9,14 +9,15 @@
  * @returns {Function}
  */
 module.exports = function(app, middlewares) {
-	let errors = app.get('errors')
+	const errors = app.get('errors')
 
 	/**
 	 * @param {Model} model
 	 * @param {Object} options
-	 * @param {String} options.attribute - attribute of ${model} to query
-	 * @param {String} options.paramName - name of query parameter to use to get the search value to search for
-	 * @param {String} options.targetName - name to assign resulting entity to in the res.locals Object
+	 * @param {Array.<String>} attributes field to fetch when searching for the entity
+	 * @param {String} options.queryAttribute attribute of ${model} to query
+	 * @param {String} options.paramName name of query parameter to use to get the search value to search for
+	 * @param {String} options.targetName name to assign resulting entity to in the res.locals Object
 	 * @returns {Function}
 	 */
 	return (model, options) => {

--- a/mist-api/src/middlewares/parse-query-params.js
+++ b/mist-api/src/middlewares/parse-query-params.js
@@ -1,0 +1,87 @@
+'use strict'
+
+module.exports = function(app) {
+  const { BadRequestError } = app.get('errors')
+
+  /**
+   * Given an array of query parameter signatures, parse / validate / clean the value
+   * from the request query object and inject into ${res.locals.cleanQuery} for later
+   * consumption.
+   *
+   * @param {Array} signatures
+   * @param {Object} signatures[]
+   * @param {any?} signatures[].defaultValue default value to be applied if key does not exist or is empty
+   * @param {string?} signatures[].hint optional hint to provide to user when value is invalid
+   * @param {Function?} signatures[].isValid method to test if value is valid; should return boolean result
+   * @param {string} signatures[].paramName query parameter name
+   * @param {Function?} signatures[].transform method to apply to value to produce final result; is not called on default value
+   */
+  return (signatures) => {
+    if (!Array.isArray(signatures))
+      throw new Error('(parseQueryParams) signatures argument must be an array')
+
+    signatures.forEach((signature, i) => {
+      const error = findSignatureError(signature)
+      if (error)
+        throw new Error(`(parseQueryParams) invalid signature at index ${i}: ${error}`)
+    })
+
+    // Core middleware function
+    return function parseQueryParams(req, res, next) {
+      const badRequestError = new BadRequestError('Invalid query parameters')
+      res.locals.cleanQuery = {}
+
+      signatures.forEach((signature) => {
+        const paramPresent = Reflect.has(req.query, signature.paramName)
+        const hasDefaultValue = signature.defaultValue !== undefined
+        if (!paramPresent) {
+          if (hasDefaultValue)
+            res.locals.cleanQuery[signature.paramName] = signature.defaultValue
+          return
+        }
+
+        const queryParamValue = req.query[signature.paramName]
+        const isValid = signature.isValid ? signature.isValid(queryParamValue) : true
+        if (!isValid) {
+          badRequestError.addValidationError(signature.paramName, signature.hint)
+          return
+        }
+
+        let cleanValue = signature.transform ? signature.transform(queryParamValue) : queryParamValue
+        res.locals.cleanQuery[signature.paramName] = cleanValue
+      })
+
+      const hasError = !!badRequestError.errors
+      const error = hasError ? badRequestError : undefined
+      next(error)
+    }
+  }
+}
+
+const findSignatureError = (signature) => {
+  if (typeof signature != 'object')
+    return 'signature must be an object'
+
+  if (Reflect.has(signature, 'hint') && typeof signature.hint !== 'string')
+    return 'signature.hint must be a string'
+
+  if (Reflect.has(signature, 'isValid') && typeof signature.isValid != 'function')
+    return 'signature.isValid must be a function'
+
+  if (!Reflect.has(signature, 'paramName'))
+    return 'signature.paramName is a required field'
+
+  if (typeof signature.paramName !== 'string')
+    return 'signature.paramName must be a string'
+
+  if (/^\s|\s$/.test(signature.paramName))
+    return `signature.paramName (${signature.paramName}) must not have any leading or trailing whitespace`
+
+  if (signature.paramName.length === 0)
+    return 'signature.paramName must not be empty'
+
+  if (Reflect.has(signature, 'transform') && typeof signature.transform !== 'function')
+    return 'signature.transform must be a function'
+
+  return null
+}

--- a/mist-api/src/middlewares/parse-query-params.tests.js
+++ b/mist-api/src/middlewares/parse-query-params.tests.js
@@ -1,0 +1,262 @@
+'use strict'
+
+// Local
+const errors = require('../lib/errors')
+const parseQueryParamsFn = require('./parse-query-params')
+
+const mockApp = {
+  get: () => errors
+}
+
+describe('middleware: parseQueryParams', () => {
+  let parseQueryParams = null;
+  let signature
+  beforeEach(() => {
+    parseQueryParams = parseQueryParamsFn(mockApp)
+    signature = {
+      defaultValue: 5,
+      hint: 'hint',
+      isValid: (value) => true,
+      paramName: 'paramName',
+      transform: () => {},
+    }
+  })
+
+  afterEach(() => {
+    parseQueryParams = null
+    signature = null
+  })
+
+  describe('signature errors', () => {
+    it('throws error if signatures is not an array', () => {
+      expect(() => {
+        parseQueryParams()
+      }).throw()
+    })
+
+    it('throws an error if signature is not an object', () => {
+      const valuesThatShouldThrow = [
+        null,
+        undefined,
+        [],
+        45,
+        'string',
+      ]
+      valuesThatShouldThrow.forEach((value) => {
+        expect(() => {
+          parseQueryParams([value])
+        }).throw()
+      })
+    })
+
+    it('throws if hint is not a string', () => {
+      expect(() => {
+        signature.hint = []
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if isValid is not a function', () => {
+      expect(() => {
+        signature.isValid = {}
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if paramName is not present', () => {
+      expect(() => {
+        delete signature.paramName
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if paramName is not a string', () => {
+      expect(() => {
+        signature.paramName = {}
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if paramName has leading whitespace', () => {
+      expect(() => {
+        signature.paramName = ' paramName'
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if paramName has trailing whitespace', () => {
+      expect(() => {
+        signature.paramName = 'paramName '
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if paramName is empty', () => {
+      expect(() => {
+        signature.paramName = ''
+        parseQueryParams([signature])
+      }).throw()
+    })
+
+    it('throws if transform is not a function', () => {
+      expect(() => {
+        signature.transform = {}
+        parseQueryParams([signature])
+      }).throw()
+    })
+  })
+
+  describe('middleware processing', () => {
+    let req
+    let res
+    let next
+    beforeEach(() => {
+      req = {
+        query: {},
+      }
+      res = {
+        locals: {}
+      }
+      next = sinon.spy()
+    })
+
+    afterEach(() => {
+      req = null
+      res = null
+      next = null
+    })
+
+    it('calls next without error if no signatures are defined', () => {
+      const signatures = []
+      const middleware = parseQueryParams(signatures)
+      middleware(req, res, next)
+      expect(next.calledWith(undefined)).true
+    })
+
+    it('assigns default value to res.locals.cleanQuery if param is not in query and signature has defined default value', () => {
+      signature.paramName = 'paramName'
+      signature.defaultValue = 10
+      const signatures = [signature]
+      const middleware = parseQueryParams(signatures)
+      middleware(req, res, next)
+      expect(res.locals.cleanQuery[signature.paramName]).equal(signature.defaultValue)
+      expect(next.calledWith(undefined)).true
+    })
+
+    it('does not assign default value to res.locals.cleanQuery if param is not in query and signature does not have default value', () => {
+      signature.paramName = 'paramName'
+      delete signature.defaultValue
+      const signatures = [signature]
+      const middleware = parseQueryParams(signatures)
+      middleware(req, res, next)
+      expect(Reflect.has(res.locals.cleanQuery, signature.paramName)).false
+      expect(next.calledWith(undefined)).true
+    })
+
+    it('calls next without error if param is not in query and signature.isValid returns false', () => {
+      signature.isValid = () => false
+      const signatures = [signature]
+      const middleware = parseQueryParams(signatures)
+      middleware(req, res, next)
+      expect(next.calledWith(undefined)).true
+    })
+
+    it('calls next with BadRequestError if param is in query and signature.isValid returns false', () => {
+      signature.isValid = () => false
+      sinon.spy(signature, 'isValid')
+      req.query[signature.paramName] = 'fake bad value'
+      const signatures = [signature]
+      const middleware = parseQueryParams(signatures)
+      middleware(req, res, next)
+      expect(signature.isValid.calledWith('fake bad value')).true
+      expect(next.calledOnce).true
+      const error = next.getCall(0).args[0]
+      expect(error).instanceof(errors.BadRequestError)
+      expect(error.errors[0].message).equal(signature.hint)
+    })
+
+    it('applies transform to param value', () => {
+      req.query[signature.paramName] = 'fake value'
+      signature.transform = (value) => value.toUpperCase()
+      sinon.spy(signature, 'transform')
+      const signatures = [signature]
+      const middleware = parseQueryParams(signatures)
+      middleware(req, res, next)
+      expect(signature.transform.calledWith('fake value')).true
+      expect(res.locals.cleanQuery[signature.paramName]).equal('FAKE VALUE')
+      expect(next.calledWith(undefined)).true
+    })
+
+    describe('multiple signatures', () => {
+      let signature1
+      let signature2
+      let signatures
+      beforeEach(() => {
+        signature1 = {
+          defaultValue: 'biowonks',
+          hint: 'who are we?',
+          isValid: (value) => value === 'coli',
+          paramName: 'name',
+          transform: (value) => value.toUpperCase(),
+        }
+        signature2 = {
+          hint: 'hint2',
+          isValid: (value) => /^\d+$/.test(value),
+          paramName: 'num',
+          transform: parseInt,
+        }
+
+        signatures = [
+          signature1,
+          signature2,
+        ]
+      })
+
+      afterEach(() => {
+        signature1 = null
+        signature2 = null
+        signatures = []
+      })
+
+      it('calls next without error when query is empty', () => {
+        const middleware = parseQueryParams(signatures)
+        middleware(req, res, next)
+        expect(next.calledWith(undefined)).true
+        expect(res.locals.cleanQuery).eql({name: 'biowonks'})
+      })
+
+      it('calls next without error when query contains valid values', () => {
+        req.query.name = 'coli'
+        req.query.num = '7'
+        const middleware = parseQueryParams(signatures)
+        middleware(req, res, next)
+        expect(next.calledWith(undefined)).true
+        expect(res.locals.cleanQuery).eql({name: 'COLI', num: 7})
+      })
+
+      it('calls next with error if one parameter fails', () => {
+        req.query.num = 'coli'
+        const middleware = parseQueryParams(signatures)
+        middleware(req, res, next)
+        expect(next.calledOnce).true
+        const error = next.getCall(0).args[0]
+        expect(error).instanceof(errors.BadRequestError)
+        expect(error.errors.length).equal(1)
+        expect(error.errors[0].path).equal('num')
+      })
+
+      it('calls next with error multiple parameter errors', () => {
+        req.query.name = 'bad name'
+        req.query.num = 'coli'
+        const middleware = parseQueryParams(signatures)
+        middleware(req, res, next)
+        expect(next.calledOnce).true
+        const error = next.getCall(0).args[0]
+        expect(error).instanceof(errors.BadRequestError)
+        expect(error.errors.length).equal(2)
+        const paths = error.errors.map((x) => x.path)
+        expect(paths).members(['name', 'num'])
+      })
+    }) // End multiple signatures
+  }) // End middleware processing
+})

--- a/mist-api/src/routes/genes/$stable_id/neighbors/get.js
+++ b/mist-api/src/routes/genes/$stable_id/neighbors/get.js
@@ -1,0 +1,91 @@
+'use strict'
+
+// Local
+const arrayUtil = require('core-lib/array-util')
+
+// Vendor
+const validator = require('validator')
+
+// Constants
+const kDefaultNeighborAmount = 5
+const kMaxNeighborAmount = 10
+
+module.exports = function(app, middlewares, routeMiddlewares) {
+  const models = app.get('models')
+  const Gene = models.Gene
+	const helper = app.get('lib').RouteHelper.for(Gene)
+
+	return [
+    middlewares.parseQueryParams(
+      [
+        {
+          defaultValue: kDefaultNeighborAmount,
+          hint: `the amount query parameter is optional and must be an integer between 0 and ${kMaxNeighborAmount}; defaults to ${kDefaultNeighborAmount}`,
+          isValid: (value) => validator.isInt(value, {min: 0, max: kMaxNeighborAmount, allow_leading_zeroes: false}),
+          paramName: 'amount',
+          transform: parseInt,
+        },
+        {
+          hint: `the amountBefore query parameter is optional and must be an integer between 0 and ${kMaxNeighborAmount}; defaults to ${kDefaultNeighborAmount} unless amount is provided`,
+          isValid: (value) => validator.isInt(value, {min: 0, max: kMaxNeighborAmount, allow_leading_zeroes: false}),
+          paramName: 'amountBefore',
+          transform: parseInt,
+        },
+        {
+          hint: `the amountAfter query parameter is optional and must be an integer between 0 and ${kMaxNeighborAmount}; defaults to ${kDefaultNeighborAmount} unless amount is provided`,
+          isValid: (value) => validator.isInt(value, {min: 0, max: kMaxNeighborAmount, allow_leading_zeroes: false}),
+          paramName: 'amountAfter',
+          transform: parseInt,
+        },
+      ]
+    ),
+    middlewares.exists(Gene, {
+      attributes: ['id', 'component_id'],
+      paramName: 'stable_id',
+      queryAttribute: 'stable_id',
+      targetName: 'gene'
+    }),
+    (req, res, next) => {
+      res.locals.gene.findNeighborIds({
+        amount: res.locals.cleanQuery.amount,
+        amountBefore: res.locals.cleanQuery.amountBefore,
+        amountAfter: res.locals.cleanQuery.amountAfter,
+      })
+      .then((result) => {
+        res.locals.neighborGeneIdRanges = result
+        next()
+      })
+      .catch(next)
+    },
+		middlewares.parseCriteriaForMany(models.Gene, {
+			accessibleModels: [
+				models.Component,
+				models.Aseq,
+				models.Dseq
+			]
+		}),
+		(req, res, next) => {
+      // Finally! Retrieve the neighboring genes
+      const { criteria, neighborGeneIdRanges } = res.locals
+
+      if (!neighborGeneIdRanges.length) {
+        res.json([])
+        return
+      }
+
+      criteria.where = {
+        $or: neighborGeneIdRanges.map((range) => {
+          return {
+            id: {
+              $between: range,
+            },
+          }
+        }),
+      }
+      criteria.limit = kMaxNeighborAmount * 2
+      Gene.findAll(criteria)
+      .then((entities) => res.json(entities))
+      .catch(next)
+    },
+	]
+}

--- a/mist-api/src/routes/genes/$stable_id/neighbors/get.js
+++ b/mist-api/src/routes/genes/$stable_id/neighbors/get.js
@@ -1,14 +1,15 @@
 'use strict'
 
+// Vendor
+const _ = require('lodash')
+const validator = require('validator')
+
 // Local
 const arrayUtil = require('core-lib/array-util')
 
-// Vendor
-const validator = require('validator')
-
 // Constants
 const kDefaultNeighborAmount = 5
-const kMaxNeighborAmount = 10
+const kMaxNeighborAmount = 15
 
 module.exports = function(app, middlewares, routeMiddlewares) {
   const models = app.get('models')
@@ -84,7 +85,13 @@ module.exports = function(app, middlewares, routeMiddlewares) {
       }
       criteria.limit = kMaxNeighborAmount * 2
       Gene.findAll(criteria)
-      .then((entities) => res.json(entities))
+      .then((entities) => {
+        // Re-order entities to be "centered" around target gene
+        const idLists = neighborGeneIdRanges.map((geneIdRange) => _.range(geneIdRange[0], geneIdRange[1] + 1))
+        const sortedIds = arrayUtil.flatten(idLists)
+        const sortedEntities = arrayUtil.sortBy(entities, sortedIds, 'id')
+        res.json(sortedEntities)
+      })
       .catch(next)
     },
 	]

--- a/mist-lib/src/models/Component.model.js
+++ b/mist-lib/src/models/Component.model.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = function(Sequelize, models, extras) {
-	let fields = {
+	const fields = {
 		genome_id: Object.assign(extras.requiredPositiveInteger(), {
 			description: 'foreign identifier to this component\'s associated genome',
 			example: 1
@@ -87,46 +87,69 @@ module.exports = function(Sequelize, models, extras) {
 		}
 	}
 
-	let instanceMethods = {
+	// Prevent selection of the dna field. This avoids sending many megabytes of data in an
+	// un-regulated manner.
+	const excludedCriteriaAttributeSet = new Set(['dna'])
+	let criteriaAttributes = new Set(['id', ...Object.keys(fields)])
+	for (let attribute of excludedCriteriaAttributeSet)
+		criteriaAttributes.delete(attribute)
+	criteriaAttributes = Array.from(criteriaAttributes)
+
+	const classMethods = {
+		/**
+		 * @returns {Set.<String>}
+		 */
+		$excludedFromCriteria: function() {
+			return excludedCriteriaAttributeSet
+		},
+
+		/**
+		 * @returns {Array.<String>}
+		 */
+		$criteriaAttributes: function() {
+			return criteriaAttributes
+		},
+
+		/**
+		 * @param {number} componentId
+		 * @returns {Promise.<number>}
+		 */
+		geneIdRange: function(componentId) {
+			const sequelize = models.Component.sequelize
+			return models.Gene.findOne({
+				attributes: [
+					[sequelize.fn('min', sequelize.col('id')), 'min_id'],
+					[sequelize.fn('max', sequelize.col('id')), 'max_id'],
+				],
+				group: [
+					'component_id',
+				],
+				where: {
+					component_id: componentId,
+				},
+			})
+			.then((result) => [result.get('min_id'), result.get('max_id')])
+		},
+	}
+
+	const instanceMethods = {
 		compoundAccession: function() {
 			return this.accession + '.' + this.version
 		}
 	}
 
-	let validate = {
+	const validate = {
 		genbankAccessionVersion: extras.validate.bothNullOrBothNotEmpty('genbank_accession',
 			'genbank_version'),
 		dnaLength: extras.validate.referencedLength('length', 'dna')
 	}
 
-	// Prevent selection of the dna field. This avoids sending many megabytes of data in an
-	// un-regulated manner.
-	let excludedCriteriaAttributeSet = new Set(['dna']),
-		criteriaAttributes = new Set(['id', ...Object.keys(fields)])
-	for (let attribute of excludedCriteriaAttributeSet)
-		criteriaAttributes.delete(attribute)
-	criteriaAttributes = Array.from(criteriaAttributes)
-
 	return {
 		fields,
 		params: {
 			instanceMethods,
-			classMethods: {
-				/**
-				 * @returns {Set.<String>}
-				 */
-				$excludedFromCriteria: function() {
-					return excludedCriteriaAttributeSet
-				},
-
-				/**
-				 * @returns {Array.<String>}
-				 */
-				$criteriaAttributes: function() {
-					return criteriaAttributes
-				}
-			},
-			validate
+			classMethods,
+			validate,
 		}
 	}
 }


### PR DESCRIPTION
### Motivation
Need to find neighboring genes relative to a given gene for components with both linear and circular topologies.

### Work done
Given an index, range of indices that constrain this index, if it should be treated circularly, and the number of indices to include before and after, returns an array of index ranges.

Implemented finding gene neighbors and exposed this via the API. Notable feature additions:
1. Gene::findNeighborIds - returns list of neighboring gene ids
1. Component::geneIdRange - returns range of member gene identifiers
1. parseQueryParams (middleware) - simplifies parsing and validating query parameters in a standard fashion
1. GET `/genes/$stable_id/neighbors` route: returns neighboring genes to that identified by $stable_id

How this applies:
A gene is identified by a serial number that monotonically increases in increments of one and constitutes an *ungapped sequence of integers*. Thus, when given a gene's identifier and the range of gene indices for its parent component, this method can be used to quickly compute the id ranges needed to find any given number of neighbors by their identifiers.

#### QA notes
In the tests below, upstream/downstream refers to its absolutely upstream/downstream position not necessarily before/after the 5' position.

#### Tests
For a gene on a linear component that is at least 10 genes upstream and 10 genes downstream:
- [x] GET /genes/$stable_id/neighbors returns a list of neighboring genes
- [x] GET /genes/$stable_id/neighbors?amount=2 returns 2 upstream and 2 downstream
- [x] GET /genes/$stable_id/neighbors?amountBefore=2&amountAfter=4 returns 2 upstream and 4 downstream
- [x] GET /genes/$stable_id/neighbors?amount=100 returns 10 upstream and 10 downstream genes

For a gene on a linear component that is the second gene from the "beginning" of the component:
- [x] GET /genes/$stable_id/neighbors returns 1 upstream gene and 5 downstream genes

For a gene on a linear component that is the second to last gene of the component:
- [x] GET /genes/$stable_id/neighbors returns 5 upstream genes and 1 downstream gene

For a gene on a circular component that is the second gene from the "beginning" of the component:
- [x] GET /genes/$stable_id/neighbors returns a) the first gene of the component, b) the last four genes from the end of the component, and c) 5 downstream genes

For a gene on a circular component that is the second to last gene of the component:
- [x] GET /genes/$stable_id/neighbors returns a) 5 upstream genes, b) the last gene of the component, and c) the first four genes of the component
