### PR TITLE
Add support for submodule dependencies

### DIFF
--- a/mist-pipeline/src/lib/AbstractPipelineModule.js
+++ b/mist-pipeline/src/lib/AbstractPipelineModule.js
@@ -43,7 +43,20 @@ class AbstractPipelineModule {
 	}
 
 	/**
-	 * @returns {Map.<String,String>} - a map with submodule names as keys, and descriptions as values
+	 * Example return value:
+	 * {
+	 *   stp: {
+	 *     description: 'predict signal transduction proteins',
+	 *     dependencies: [
+	 *       'AseqCompute:pfam',
+	 *       'AseqCompute:agfam',
+	 *       ...
+	 *     ]
+	 *   },
+	 *   ...
+	 * }
+	 *
+	 * @returns {Map.<String,Object>} - a map with submodule names as keys that maps to an object with a description and dependencies keys
 	 */
 	static subModuleMap() {
 		return new Map()

--- a/mist-pipeline/src/lib/ModuleDepGraph.js
+++ b/mist-pipeline/src/lib/ModuleDepGraph.js
@@ -1,6 +1,7 @@
 'use strict'
 
 // Local
+let arrayUtil = require('core-lib/array-util')
 let ModuleId = require('./ModuleId')
 
 module.exports =
@@ -195,6 +196,29 @@ class ModuleDepGraph {
 
 	reverseOrderByDepth(moduleIds) {
 		return this.orderByDepth(moduleIds, true)
+	}
+
+	/**
+	 * @param {Array.<ModuleId>} moduleIds array of unnested module ids
+	 * @returns {Array.<ModuleId>} array of nested module ids sorted by depth and then nested at each depth level
+	 */
+	orderAndNestByDepth(moduleIds) {
+		// Nest nodes with the same name at the same depth
+		const nodesByDepth = {}
+		this.toNodes(moduleIds)
+			.forEach((node) => {
+				const depth = node.depth()
+				if (!nodesByDepth[depth])
+					nodesByDepth[depth] = []
+				const moduleId = ModuleId.fromString(node.name())
+				nodesByDepth[depth].push(moduleId)
+			})
+
+		const nestedAtDepth = Object.keys(nodesByDepth)
+			.sort((a, b) => a - b)
+			.map((depth) => ModuleId.nest(nodesByDepth[depth]))
+
+		return arrayUtil.flatten(nestedAtDepth)
 	}
 
 	/**

--- a/mist-pipeline/src/lib/ModuleDepGraph.tests.js
+++ b/mist-pipeline/src/lib/ModuleDepGraph.tests.js
@@ -6,351 +6,459 @@
 const bunyan = require('bunyan')
 
 // Local
-const MistBootService = require('mist-lib/services/MistBootService'),
-	ModuleDepNode = require('./ModuleDepNode'),
-	ModuleDepGraph = require('./ModuleDepGraph'),
-	ModuleId = require('./ModuleId')
+const MistBootService = require('mist-lib/services/MistBootService')
+const ModuleDepNode = require('./ModuleDepNode')
+const ModuleDepGraph = require('./ModuleDepGraph')
+const ModuleId = require('./ModuleId')
 
-describe('pipeline', function() {
-	describe('ModuleDepGraph', function() {
-		let models = null,
-			WorkerModule = null
-		before(() => {
-			let bootService = new MistBootService()
-			models = bootService.setupModels()
-			WorkerModule = models.WorkerModule
+describe('ModuleDepGraph', function() {
+	let models = null
+	let WorkerModule = null
+	before(() => {
+		let bootService = new MistBootService()
+		models = bootService.setupModels()
+		WorkerModule = models.WorkerModule
+	})
+
+	after(() => {
+		models = null
+		WorkerModule = null
+	})
+
+	const logger = bunyan.createLogger({name: 'ModuleDepGraph test'})
+	const depList = [
+		{name: 'A',		dependencies: []},
+		{name: 'B',		dependencies: []},
+		{name: 'C',		dependencies: ['B']},
+		{name: 'D',		dependencies: ['B']},
+		{name: 'E',		dependencies: ['B']},
+		{name: 'F',		dependencies: ['C', 'D']},
+		{name: 'G',		dependencies: []},
+		{name: 'H',		dependencies: ['F', 'G']},
+	]
+	const root = ModuleDepNode.createFromDepList(depList)
+	const nameMap = root.nameNodeMap()
+	const A = nameMap.get('A'),	Aid = new ModuleId('A')
+	const B = nameMap.get('B'),	Bid = new ModuleId('B')
+	const C = nameMap.get('C'),	Cid = new ModuleId('C')
+	const D = nameMap.get('D'),	Did = new ModuleId('D')
+	const F = nameMap.get('F'),	Fid = new ModuleId('F')
+	const G = nameMap.get('G'),	Gid = new ModuleId('G')
+	const H = nameMap.get('H'),	Hid = new ModuleId('H')
+
+	beforeEach(() => {
+		root.traverse((node) => {
+			node.setWorkerModule(null)
+		})
+	})
+
+	function checkModuleIdArray(result, expectedArray) {
+		expect(result).a('array')
+		expect(result.length).equal(expectedArray.length)
+		result.forEach((moduleId, i) => {
+			expect(moduleId.toString()).equal(expectedArray[i].toString())
+		})
+	}
+
+	it('constructor and default state', function() {
+		new ModuleDepGraph(root, logger)
+	})
+
+	describe('loadState', function() {
+		it('sets worker modules to identically named nodes', function() {
+			const x = new ModuleDepGraph(root, logger)
+			const wmA = WorkerModule.build({module: 'A'})
+			const wmH = WorkerModule.build({module: 'H'})
+			x.loadState([wmA, wmH])
+			root.traverse((node) => {
+				if (node.name() === 'A')
+					expect(node.workerModule()).equal(wmA)
+				else if (node.name() === 'H')
+					expect(node.workerModule()).equal(wmH)
+				else
+					expect(node.workerModule()).null
+			})
 		})
 
-		let logger = bunyan.createLogger({name: 'ModuleDepGraph test'}),
-			depList = [
-				{name: 'A',		dependencies: []},
-				{name: 'B',		dependencies: []},
-				{name: 'C',		dependencies: ['B']},
-				{name: 'D',		dependencies: ['B']},
-				{name: 'E',		dependencies: ['B']},
-				{name: 'F',		dependencies: ['C', 'D']},
-				{name: 'G',		dependencies: []},
-				{name: 'H',		dependencies: ['F', 'G']}
-			],
-			root = ModuleDepNode.createFromDepList(depList),
-			nameMap = root.nameNodeMap(),
-			A = nameMap.get('A'),	Aid = new ModuleId('A'),
-			B = nameMap.get('B'),	Bid = new ModuleId('B'),
-			C = nameMap.get('C'),	Cid = new ModuleId('C'),
-			D = nameMap.get('D'),	Did = new ModuleId('D'),
-			F = nameMap.get('F'),	Fid = new ModuleId('F'),
-			G = nameMap.get('G'),	Gid = new ModuleId('G'),
-			H = nameMap.get('H'),	Hid = new ModuleId('H')
+		it('throws error if no logger and attempt to load non-cognate worker module', function() {
+			const x = new ModuleDepGraph(root)
+			const wm = WorkerModule.build({module: 'Doesnt exist'})
+			expect(function() {
+				x.loadState([wm])
+			}).throw(Error)
+		})
+
+		it('clears any previously defined state', function() {
+			const x = new ModuleDepGraph(root, logger)
+			const wmA = WorkerModule.build({module: 'A'})
+			const wmH = WorkerModule.build({module: 'H'})
+			x.loadState([wmA, wmH])
+			expect(A.workerModule()).equal(wmA)
+			expect(H.workerModule()).equal(wmH)
+			x.loadState([])
+			root.traverse((node) => {
+				expect(node.workerModule()).null
+			})
+		})
+	})
+
+	describe('updateState', function() {
+		it('sets worker modules to identically named nodes and does not clear previous state', function() {
+			const x = new ModuleDepGraph(root, logger)
+			const wmA = WorkerModule.build({module: 'A'})
+			const wmH = WorkerModule.build({module: 'H'})
+			x.loadState([wmA])
+			x.updateState([wmH])
+			root.traverse((node) => {
+				if (node.name() === 'A')
+					expect(node.workerModule()).equal(wmA)
+				else if (node.name() === 'H')
+					expect(node.workerModule()).equal(wmH)
+				else
+					expect(node.workerModule()).null
+			})
+		})
+
+		it('throws error if no logger and attempt to update non-cognate worker module', function() {
+			const x = new ModuleDepGraph(root)
+			const wm = WorkerModule.build({module: 'Doesnt exist'})
+			expect(function() {
+				x.updateState([wm])
+			}).throw(Error)
+		})
+	})
+
+	describe('removeState', function() {
+		it('removes any matching worker modules', function() {
+			const x = new ModuleDepGraph(root, logger)
+			const wmA = WorkerModule.build({module: 'A'})
+			const wmH = WorkerModule.build({module: 'H'})
+			x.loadState([wmA])
+			x.removeState([wmH])
+			root.traverse((node) => {
+				if (node.name() === 'A')
+					expect(node.workerModule()).equal(wmA)
+				else
+					expect(node.workerModule()).null
+			})
+		})
+
+		it('throws error if no logger and attempt to remove non-cognate worker module', function() {
+			const x = new ModuleDepGraph(root)
+			const wm = WorkerModule.build({module: 'Doesnt exist'})
+			expect(function() {
+				x.removeState([wm])
+			}).throw(Error)
+		})
+	})
+
+	describe('moduleIdsInStates', function() {
+		let x = null
+		beforeEach(() => {
+			x = new ModuleDepGraph(root, logger)
+		})
+
+		afterEach(() => {
+			x = null
+		})
 
 		beforeEach(() => {
-			root.traverse((node) => {
-				node.setWorkerModule(null)
+			const wmA = WorkerModule.build({module: 'A', state: 'done'})
+			const wmB = WorkerModule.build({module: 'B', state: 'done'})
+			const wmC = WorkerModule.build({module: 'C', state: 'active'})
+			const wmD = WorkerModule.build({module: 'D', state: 'undo'})
+			const wmE = WorkerModule.build({module: 'E', state: 'error'})
+			x.loadState([wmA, wmB, wmC, wmD, wmE])
+		})
+
+		it('no states listed, returns empty array', function() {
+			expect(x.moduleIdsInStates()).eql([])
+		})
+
+		it('done states', function() {
+			const result = x.moduleIdsInStates('done')
+			checkModuleIdArray(result, [Aid, Bid])
+		})
+
+		it('mixed array of states', function() {
+			const result = x.moduleIdsInStates('active', 'undo')
+			checkModuleIdArray(result, [Cid, Did])
+		})
+	})
+
+	describe('missingDependencies', function() {
+		let x = null
+		beforeEach(() => {
+			x = new ModuleDepGraph(root)
+		})
+
+		afterEach(() => {
+			x = null
+		})
+
+		describe('empty state', function() {
+			it('"root" nodes have no missing dependencies', function() {
+				expect(x.missingDependencies(Aid)).eql([])
+				expect(x.missingDependencies(Bid)).eql([])
+			})
+
+			it('C missing B', function() {
+				expect(x.missingDependencies(Cid)).eql(['B'])
+			})
+
+			it('F missing C, B, and D', function() {
+				expect(x.missingDependencies(Fid)).eql(['C', 'B', 'D'])
+			})
+
+			it('H missing F, C, B, D, E, and G', function() {
+				expect(x.missingDependencies(Hid)).eql(['F', 'C', 'B', 'D', 'G'])
 			})
 		})
 
-		function checkModuleIdArray(result, expectedArray) {
-			expect(result).a('array')
-			expect(result.length).equal(expectedArray.length)
-			result.forEach((moduleId, i) => {
-				expect(moduleId.toString()).equal(expectedArray[i].toString())
+		describe('partial state', function() {
+			it('done B, C has no missing dependencies', function() {
+				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
+				expect(x.missingDependencies(Cid)).eql([])
 			})
+
+			it('error B count as missing dependency', function() {
+				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'error'}))
+				expect(x.missingDependencies(Cid)).eql(['B'])
+			})
+
+			it('B undone, C done, D done, F input returns B as missing dependency', function() {
+				C.setWorkerModule(WorkerModule.build({module: 'C', state: 'done'}))
+				D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
+				expect(x.missingDependencies(Fid)).eql(['B'])
+			})
+
+			it('multiple dependencies', function() {
+				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
+				C.setWorkerModule(WorkerModule.build({module: 'C', state: 'error'}))
+				D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
+				expect(x.missingDependencies(Hid)).eql(['F', 'C', 'G'])
+			})
+		})
+
+		describe('submodule checks', function() {
+			let root = null
+			beforeEach(() => {
+				const depList = [
+					{name: 'A',				dependencies: []},
+					{name: 'B',				dependencies: ['A']},
+					{name: 'C:agfam',	dependencies: ['A']},
+					{name: 'C:pfam',	dependencies: ['A']},
+					{name: 'C:seg',		dependencies: ['A']},
+					{name: 'C:stp',		dependencies: ['C:pfam', 'C:agfam']},
+				]
+
+				root = ModuleDepNode.createFromDepList(depList)
+				x = new ModuleDepGraph(root)
+			})
+
+			it('C:stp depends on C:pfam, C:agfam, A', function() {
+				const stp = new ModuleId('C', ['stp'])
+
+				expect(x.missingDependencies(stp)).eql(['C:pfam', 'A', 'C:agfam'])
+			})
+
+			it('C:pfam done, A done, C:agfam undone C:stp returns c:agfam', function() {
+				const stp = new ModuleId('C', ['stp'])
+				const nameMap = root.nameNodeMap()
+				nameMap.get('A').setWorkerModule(WorkerModule.build({module: 'A', state: 'done'}))
+				nameMap.get('C:pfam').setWorkerModule(WorkerModule.build({module: 'C:pfam', state: 'done'}));
+
+				expect(x.missingDependencies(stp)).eql(['C:agfam'])
+			})
+		})
+	})
+
+	describe('moduleIdsDependingOn', function() {
+		let x = null
+		beforeEach(() => {
+			x = new ModuleDepGraph(root)
+		})
+
+		afterEach(() => {
+			x = null
+		})
+
+		it('no worker modules returns empty array', function() {
+			expect(x.moduleIdsDependingOn(Aid)).eql([])
+			expect(x.moduleIdsDependingOn(Bid)).eql([])
+			expect(x.moduleIdsDependingOn(Fid)).eql([])
+		})
+
+		it('does not include currently referenced node', function() {
+			B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
+			expect(x.moduleIdsDependingOn(Bid)).eql([])
+		})
+
+		it('all descendant nodes with done worker modules are identified', function() {
+			B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
+			C.setWorkerModule(WorkerModule.build({module: 'C', state: 'error'}))
+			D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
+			F.setWorkerModule(WorkerModule.build({module: 'F', state: 'done'}))
+
+			const result = x.moduleIdsDependingOn(Bid)
+			checkModuleIdArray(result, [Fid, Did])
+		})
+	})
+
+	describe('doneModuleIds', function() {
+		it('returns moduleIds that are done', function() {
+			const x = new ModuleDepGraph(root)
+			B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
+			C.setWorkerModule(WorkerModule.build({module: 'C', state: 'error'}))
+			D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
+			F.setWorkerModule(WorkerModule.build({module: 'F', state: 'done'}))
+
+			expect(x.doneModuleIds([])).eql([])
+			expect(x.doneModuleIds([Aid])).eql([])
+			checkModuleIdArray(x.doneModuleIds([Aid, Bid]), [Bid])
+
+			checkModuleIdArray(x.doneModuleIds([
+				Aid, Bid, Cid, Fid, Gid, Hid // Note - Did is excluded
+			]), [Bid, Fid])
+		})
+	})
+
+	describe('matchingModuleIds', function() {
+		it('returns matching modules based on our custom matching function', function() {
+			const x = new ModuleDepGraph(root)
+			const result = x.matchingModuleIds([Aid, Bid, Hid], (node) => /^(A|H)$/.test(node.name()))
+
+			checkModuleIdArray(result, [Aid, Hid])
+		})
+	})
+
+	describe('incompleteModuleIds', function() {
+		const x = new ModuleDepGraph(root)
+		it('no worker module is incomplete', function() {
+			const result = x.incompleteModuleIds([Aid])
+			checkModuleIdArray(result, [Aid])
+		})
+
+		it('worker module with done state is not incomplete', function() {
+			G.setWorkerModule(WorkerModule.build({module: 'G', state: 'done'}))
+			expect(x.incompleteModuleIds([Gid])).eql([])
+		})
+
+		it('multiple module ids as input', function() {
+			A.setWorkerModule(WorkerModule.build({module: 'A', state: 'done'}))
+			B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
+			D.setWorkerModule(WorkerModule.build({module: 'D', state: 'error'}))
+
+			const result = x.incompleteModuleIds([Aid, Bid, Cid, Did])
+			checkModuleIdArray(result, [Cid, Did])
+		})
+	})
+
+	describe('orderByDepth', function() {
+		let x = null
+		beforeEach(() => {
+			x = new ModuleDepGraph(root)
+		})
+
+		afterEach(() => {
+			x = null
+		})
+
+		function checkOrder(input, output) {
+			let result = x.orderByDepth(input)
+			checkModuleIdArray(result, output)
 		}
 
-		it('constructor and default state', function() {
-			new ModuleDepGraph(root, logger)
+		it('[C, B] -> [B, C]', function() {
+			checkOrder([Cid, Bid], [Bid, Cid])
 		})
 
-		describe('loadState', function() {
-			it('sets worker modules to identically named nodes', function() {
-				let x = new ModuleDepGraph(root, logger),
-					wmA = WorkerModule.build({module: 'A'}),
-					wmH = WorkerModule.build({module: 'H'})
-				x.loadState([wmA, wmH])
-				root.traverse((node) => {
-					if (node.name() === 'A')
-						expect(node.workerModule()).equal(wmA)
-					else if (node.name() === 'H')
-						expect(node.workerModule()).equal(wmH)
-					else
-						expect(node.workerModule()).null
-				})
-			})
-
-			it('throws error if no logger and attempt to load non-cognate worker module', function() {
-				let x = new ModuleDepGraph(root),
-					wm = WorkerModule.build({module: 'Doesnt exist'})
-				expect(function() {
-					x.loadState([wm])
-				}).throw(Error)
-			})
-
-			it('clears any previously defined state', function() {
-				let x = new ModuleDepGraph(root, logger),
-					wmA = WorkerModule.build({module: 'A'}),
-					wmH = WorkerModule.build({module: 'H'})
-				x.loadState([wmA, wmH])
-				expect(A.workerModule()).equal(wmA)
-				expect(H.workerModule()).equal(wmH)
-				x.loadState([])
-				root.traverse((node) => {
-					expect(node.workerModule()).null
-				})
-			})
+		it('[H, B] -> [B, H]', function() {
+			checkOrder([Hid, Bid], [Bid, Hid])
 		})
 
-		describe('updateState', function() {
-			it('sets worker modules to identically named nodes and does not clear previous state', function() {
-				let x = new ModuleDepGraph(root, logger),
-					wmA = WorkerModule.build({module: 'A'}),
-					wmH = WorkerModule.build({module: 'H'})
-				x.loadState([wmA])
-				x.updateState([wmH])
-				root.traverse((node) => {
-					if (node.name() === 'A')
-						expect(node.workerModule()).equal(wmA)
-					else if (node.name() === 'H')
-						expect(node.workerModule()).equal(wmH)
-					else
-						expect(node.workerModule()).null
-				})
-			})
-
-			it('throws error if no logger and attempt to update non-cognate worker module', function() {
-				let x = new ModuleDepGraph(root),
-					wm = WorkerModule.build({module: 'Doesnt exist'})
-				expect(function() {
-					x.updateState([wm])
-				}).throw(Error)
-			})
+		it('[C, F, A, D, B] -> [A, B, C, D, F]', function() {
+			checkOrder([Cid, Fid, Aid, Did, Bid], [Aid, Bid, Cid, Did, Fid])
 		})
 
-		describe('removeState', function() {
-			it('removes any matching worker modules', function() {
-				let x = new ModuleDepGraph(root, logger),
-					wmA = WorkerModule.build({module: 'A'}),
-					wmH = WorkerModule.build({module: 'H'})
-				x.loadState([wmA])
-				x.removeState([wmH])
-				root.traverse((node) => {
-					if (node.name() === 'A')
-						expect(node.workerModule()).equal(wmA)
-					else
-						expect(node.workerModule()).null
-				})
-			})
+		it('[D, C] -> [D, C]', function() {
+			checkOrder([Did, Cid], [Did, Cid])
+		})
+	})
 
-			it('throws error if no logger and attempt to remove non-cognate worker module', function() {
-				let x = new ModuleDepGraph(root),
-					wm = WorkerModule.build({module: 'Doesnt exist'})
-				expect(function() {
-					x.removeState([wm])
-				}).throw(Error)
-			})
+	describe('reverseOrderByDepth', function() {
+		let x = null
+		beforeEach(() => {
+			x = new ModuleDepGraph(root)
 		})
 
-		describe('moduleIdsInStates', function() {
+		afterEach(() => {
+			x = null
+		})
+
+		function checkReverseOrder(input, output) {
+			const result = x.reverseOrderByDepth(input)
+			checkModuleIdArray(result, output)
+		}
+
+		it('[B, C] -> [C, B]', function() {
+			checkReverseOrder([Bid, Cid], [Cid, Bid])
+		})
+
+		it('[B, H] -> [H, B]', function() {
+			checkReverseOrder([Bid, Hid], [Hid, Bid])
+		})
+
+		it('[A, C, D, F, B] -> [F, C, D, A, B]', function() {
+			checkReverseOrder([Aid, Cid, Did, Fid, Bid], [Fid, Cid, Did, Aid, Bid])
+		})
+
+		it('[C, D] -> [C, D]', function() {
+			checkReverseOrder([Cid, Did], [Cid, Did])
+		})
+	})
+
+	describe('orderAndNestByDepth', () => {
+		let root = null
+		beforeEach(() => {
+			const depList = [
+				{name: 'A',				dependencies: []},
+				{name: 'B',				dependencies: ['A']},
+				{name: 'C:agfam',	dependencies: ['A']},
+				{name: 'C:pfam',	dependencies: ['A']},
+				{name: 'C:seg',		dependencies: ['A']},
+				{name: 'C:stp',		dependencies: ['C:pfam', 'C:agfam']},
+			]
+
+			root = ModuleDepNode.createFromDepList(depList)
+		})
+
+		afterEach(() => {
+			root = null
+		})
+
+		it('C:agfam, C:pfam, C:stp returns [C:agfam+pfam, C:stp]', function() {
+			const A = new ModuleId('A')
+			const agfam = new ModuleId('C', ['agfam'])
+			const pfam = new ModuleId('C', ['pfam'])
+			const seg = new ModuleId('C', ['seg'])
+			const stp = new ModuleId('C', ['stp'])
 			let x = new ModuleDepGraph(root, logger)
-
-			beforeEach(() => {
-				let wmA = WorkerModule.build({module: 'A', state: 'done'}),
-					wmB = WorkerModule.build({module: 'B', state: 'done'}),
-					wmC = WorkerModule.build({module: 'C', state: 'active'}),
-					wmD = WorkerModule.build({module: 'D', state: 'undo'}),
-					wmE = WorkerModule.build({module: 'E', state: 'error'})
-				x.loadState([wmA, wmB, wmC, wmD, wmE])
-			})
-
-			it('no states listed, returns empty array', function() {
-				expect(x.moduleIdsInStates()).eql([])
-			})
-
-			it('done states', function() {
-				let result = x.moduleIdsInStates('done')
-				checkModuleIdArray(result, [Aid, Bid])
-			})
-
-			it('mixed array of states', function() {
-				let result = x.moduleIdsInStates('active', 'undo')
-				checkModuleIdArray(result, [Cid, Did])
-			})
+			const result = x.orderAndNestByDepth([A, stp, pfam, seg, agfam])
+			expect(result.length).equal(3)
+			expect(result[0].name()).equal('A')
+			expect(result[0].subNames()).eql([])
+			expect(result[1].name()).equal('C')
+			expect(result[1].subNames()).members(['agfam', 'pfam', 'seg'])
+			expect(result[2].name()).equal('C')
+			expect(result[2].subNames()).eql(['stp'])
 		})
+	})
 
-		describe('missingDependencies', function() {
-			let x = new ModuleDepGraph(root)
-			describe('empty state', function() {
-				it('"root" nodes have no missing dependencies', function() {
-					expect(x.missingDependencies(Aid)).eql([])
-					expect(x.missingDependencies(Bid)).eql([])
-				})
-
-				it('C missing B', function() {
-					expect(x.missingDependencies(Cid)).eql(['B'])
-				})
-
-				it('F missing C, B, and D', function() {
-					expect(x.missingDependencies(Fid)).eql(['C', 'B', 'D'])
-				})
-
-				it('H missing F, C, B, D, E, and G', function() {
-					expect(x.missingDependencies(Hid)).eql(['F', 'C', 'B', 'D', 'G'])
-				})
-			})
-
-			describe('partial state', function() {
-				it('done B, C has no missing dependencies', function() {
-					B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
-					expect(x.missingDependencies(Cid)).eql([])
-				})
-
-				it('error B count as missing dependency', function() {
-					B.setWorkerModule(WorkerModule.build({module: 'B', state: 'error'}))
-					expect(x.missingDependencies(Cid)).eql(['B'])
-				})
-
-				it('B undone, C done, D done, F input returns B as missing dependency', function() {
-					C.setWorkerModule(WorkerModule.build({module: 'C', state: 'done'}))
-					D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
-					expect(x.missingDependencies(Fid)).eql(['B'])
-				})
-
-				it('multiple dependencies', function() {
-					B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
-					C.setWorkerModule(WorkerModule.build({module: 'C', state: 'error'}))
-					D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
-					expect(x.missingDependencies(Hid)).eql(['F', 'C', 'G'])
-				})
-			})
-		})
-
-		describe('moduleIdsDependingOn', function() {
-			let x = new ModuleDepGraph(root)
-
-			it('no worker modules returns empty array', function() {
-				expect(x.moduleIdsDependingOn(Aid)).eql([])
-				expect(x.moduleIdsDependingOn(Bid)).eql([])
-				expect(x.moduleIdsDependingOn(Fid)).eql([])
-			})
-
-			it('does not include currently referenced node', function() {
-				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
-				expect(x.moduleIdsDependingOn(Bid)).eql([])
-			})
-
-			it('all descendant nodes with done worker modules are identified', function() {
-				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
-				C.setWorkerModule(WorkerModule.build({module: 'C', state: 'error'}))
-				D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
-				F.setWorkerModule(WorkerModule.build({module: 'F', state: 'done'}))
-
-				let result = x.moduleIdsDependingOn(Bid)
-				checkModuleIdArray(result, [Fid, Did])
-			})
-		})
-
-		describe('doneModuleIds', function() {
-			it('returns moduleIds that are done', function() {
-				let x = new ModuleDepGraph(root)
-				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
-				C.setWorkerModule(WorkerModule.build({module: 'C', state: 'error'}))
-				D.setWorkerModule(WorkerModule.build({module: 'D', state: 'done'}))
-				F.setWorkerModule(WorkerModule.build({module: 'F', state: 'done'}))
-
-				expect(x.doneModuleIds([])).eql([])
-				expect(x.doneModuleIds([Aid])).eql([])
-				checkModuleIdArray(x.doneModuleIds([Aid, Bid]), [Bid])
-
-				checkModuleIdArray(x.doneModuleIds([
-					Aid, Bid, Cid, Fid, Gid, Hid // Note - Did is excluded
-				]), [Bid, Fid])
-			})
-		})
-
-		describe('matchingModuleIds', function() {
-			it('returns matching modules based on our custom matching function', function() {
-				let x = new ModuleDepGraph(root),
-					result = x.matchingModuleIds([Aid, Bid, Hid], (node) => /^(A|H)$/.test(node.name()))
-
-				checkModuleIdArray(result, [Aid, Hid])
-			})
-		})
-
-		describe('incompleteModuleIds', function() {
-			let x = new ModuleDepGraph(root)
-			it('no worker module is incomplete', function() {
-				let result = x.incompleteModuleIds([Aid])
-				checkModuleIdArray(result, [Aid])
-			})
-
-			it('worker module with done state is not incomplete', function() {
-				G.setWorkerModule(WorkerModule.build({module: 'G', state: 'done'}))
-				expect(x.incompleteModuleIds([Gid])).eql([])
-			})
-
-			it('multiple module ids as input', function() {
-				A.setWorkerModule(WorkerModule.build({module: 'A', state: 'done'}))
-				B.setWorkerModule(WorkerModule.build({module: 'B', state: 'done'}))
-				D.setWorkerModule(WorkerModule.build({module: 'D', state: 'error'}))
-
-				let result = x.incompleteModuleIds([Aid, Bid, Cid, Did])
-				checkModuleIdArray(result, [Cid, Did])
-			})
-		})
-
-		describe('orderByDepth', function() {
-			let x = new ModuleDepGraph(root)
-
-			function checkOrder(input, output) {
-				let result = x.orderByDepth(input)
-				checkModuleIdArray(result, output)
-			}
-
-			it('[C, B] -> [B, C]', function() {
-				checkOrder([Cid, Bid], [Bid, Cid])
-			})
-
-			it('[H, B] -> [B, H]', function() {
-				checkOrder([Hid, Bid], [Bid, Hid])
-			})
-
-			it('[C, F, A, D, B] -> [A, B, C, D, F]', function() {
-				checkOrder([Cid, Fid, Aid, Did, Bid], [Aid, Bid, Cid, Did, Fid])
-			})
-
-			it('[D, C] -> [D, C]', function() {
-				checkOrder([Did, Cid], [Did, Cid])
-			})
-		})
-
-		describe('reverseOrderByDepth', function() {
-			let x = new ModuleDepGraph(root)
-
-			function checkReverseOrder(input, output) {
-				let result = x.reverseOrderByDepth(input)
-				checkModuleIdArray(result, output)
-			}
-
-			it('[B, C] -> [C, B]', function() {
-				checkReverseOrder([Bid, Cid], [Cid, Bid])
-			})
-
-			it('[B, H] -> [H, B]', function() {
-				checkReverseOrder([Bid, Hid], [Hid, Bid])
-			})
-
-			it('[A, C, D, F, B] -> [F, C, D, A, B]', function() {
-				checkReverseOrder([Aid, Cid, Did, Fid, Bid], [Fid, Cid, Did, Aid, Bid])
-			})
-
-			it('[C, D] -> [C, D]', function() {
-				checkReverseOrder([Cid, Did], [Cid, Did])
-			})
-		})
-
-		describe('toNodes', function() {
-			let x = new ModuleDepGraph(root)
-			it('[A, F, G] returns those nodes', function() {
-				expect(x.toNodes([Aid, Fid, Gid])).eql([A, F, G])
-			})
+	describe('toNodes', function() {
+		it('[A, F, G] returns those nodes', function() {
+			const x = new ModuleDepGraph(root)
+			expect(x.toNodes([Aid, Fid, Gid])).eql([A, F, G])
 		})
 	})
 })

--- a/mist-pipeline/src/lib/putil.tests.js
+++ b/mist-pipeline/src/lib/putil.tests.js
@@ -6,16 +6,17 @@
 const path = require('path')
 
 // Local
-const putil = require('./putil'),
-	ModuleId = require('./ModuleId'),
+const putil = require('./putil')
+const ModuleId = require('./ModuleId')
 
-	OnceOneModule = require('./test-data/module-dir1/OnceOneModule'),
-	OnceTwoModule = require('./test-data/module-dir1/OnceTwoModule'),
-	PerGenomeOneModule = require('./test-data/module-dir1/PerGenomeOneModule'),
+const OnceOneModule = require('./test-data/module-dir1/OnceOneModule')
+const OnceTwoModule = require('./test-data/module-dir1/OnceTwoModule')
+const PerGenomeOneModule = require('./test-data/module-dir1/PerGenomeOneModule')
 
-	OnceThreeModule = require('./test-data/module-dir2/OnceThreeModule'),
-	PerGenomeTwoModule = require('./test-data/module-dir2/PerGenomeTwoModule'),
-	PerGenomeThreeModule = require('./test-data/module-dir2/PerGenomeThreeModule')
+const OnceThreeModule = require('./test-data/module-dir2/OnceThreeModule')
+const PerGenomeTwoModule = require('./test-data/module-dir2/PerGenomeTwoModule')
+const PerGenomeThreeModule = require('./test-data/module-dir2/PerGenomeThreeModule')
+const PerGenomeFourModule = require('./test-data/module-dir2/PerGenomeFourModule')
 
 describe('pipeline', function() {
 	describe('putil', function() {
@@ -33,8 +34,13 @@ describe('pipeline', function() {
 
 			expect(x).property('perGenome')
 			expect(x.perGenome).a('array')
-			expect(x.perGenome.length).equal(3)
-			expect(x.perGenome).members([PerGenomeOneModule, PerGenomeTwoModule, PerGenomeThreeModule])
+			expect(x.perGenome.length).equal(4)
+			expect(x.perGenome).members([
+				PerGenomeOneModule,
+				PerGenomeTwoModule,
+				PerGenomeThreeModule,
+				PerGenomeFourModule,
+			])
 
 			expect(x).property('all')
 			expect(x.all).eql([...x.once, ...x.perGenome])
@@ -87,33 +93,48 @@ describe('pipeline', function() {
 		})
 
 		it('unnestedDependencyArray', function() {
-			let x = putil.unnestedDependencyArray([
+			const x = putil.unnestedDependencyArray([
 				OnceOneModule,
 				OnceTwoModule,
 				PerGenomeOneModule,
-				PerGenomeTwoModule
+				PerGenomeTwoModule,
+				PerGenomeFourModule,
 			])
 			expect(x).eql([
 				{
 					name: 'OnceOneModule',
-					dependencies: []
+					dependencies: [],
 				},
 				{
 					name: 'OnceTwoModule',
-					dependencies: []
+					dependencies: [],
 				},
 				{
 					name: 'PerGenomeOneModule:subModule1',
-					dependencies: ['OnceTwoModule']
+					dependencies: ['OnceTwoModule'],
 				},
 				{
 					name: 'PerGenomeOneModule:subModule2',
-					dependencies: ['OnceTwoModule']
+					dependencies: ['OnceTwoModule'],
 				},
 				{
 					name: 'PerGenomeTwoModule',
-					dependencies: []
-				}
+					dependencies: [],
+				},
+				{
+					name: 'PerGenomeFourModule:subModule1',
+					dependencies: [
+						'OnceTwoModule',
+						'PerGenomeTwoModule',
+					],
+				},
+				{
+					name: 'PerGenomeFourModule:subModule2',
+					dependencies: [
+						'OnceTwoModule',
+						'PerGenomeOneModule:subModule1',
+					],
+				},
 			])
 		})
 

--- a/mist-pipeline/src/lib/services/AseqsComputeService/tool-runners/AbstractToolRunner.js
+++ b/mist-pipeline/src/lib/services/AseqsComputeService/tool-runners/AbstractToolRunner.js
@@ -140,5 +140,6 @@ class AbstractToolRunner extends EventEmitter {
  */
 module.exports.meta = {
 	id: null,			// Unique string identifying this tool
-	description: null
+	dependencies: [],
+	description: null,
 }

--- a/mist-pipeline/src/lib/test-data/module-dir2/PerGenomeFourModule.js
+++ b/mist-pipeline/src/lib/test-data/module-dir2/PerGenomeFourModule.js
@@ -4,7 +4,7 @@
 const PerGenomePipelineModule = require('../../PerGenomePipelineModule')
 
 module.exports =
-class PerGenomeOneModule extends PerGenomePipelineModule {
+class PerGenomeFourModule extends PerGenomePipelineModule {
 	static dependencies() {
 		return ['OnceTwoModule']
 	}
@@ -15,14 +15,18 @@ class PerGenomeOneModule extends PerGenomePipelineModule {
 				'subModule1',
 				{
 					description: 'subModule 1 description',
-					dependencies: [],
+					dependencies: [
+            'PerGenomeTwoModule',
+          ],
 				},
 			],
 			[
 				'subModule2',
 				{
 					description: 'subModule 2 description',
-					dependencies: [],
+					dependencies: [
+            'PerGenomeOneModule:subModule1',
+          ],
 				},
 			],
 		])

--- a/mist-pipeline/src/modules/per-genome/AseqCompute.js
+++ b/mist-pipeline/src/modules/per-genome/AseqCompute.js
@@ -4,14 +4,20 @@
 const assert = require('assert')
 
 // Local
-const PerGenomePipelineModule = require('lib/PerGenomePipelineModule'),
-	AseqsComputeService = require('lib/services/AseqsComputeService'),
-	AseqModelFn = require('seqdepot-lib/models/Aseq.model')
+const PerGenomePipelineModule = require('lib/PerGenomePipelineModule')
+const AseqsComputeService = require('lib/services/AseqsComputeService')
+const AseqModelFn = require('seqdepot-lib/models/Aseq.model')
 
 // Other
-const kAseqModelToolIdSet = new Set(AseqModelFn.kToolIdFieldNames),
-	kSupportedTools = AseqsComputeService.tools().filter((x) => kAseqModelToolIdSet.has(x.id)),
-	kSupportedSubModuleMap = new Map(kSupportedTools.map((x) => [x.id, x.description]))
+const kAseqModelToolIdSet = new Set(AseqModelFn.kToolIdFieldNames)
+const kSupportedTools = AseqsComputeService.tools().filter((x) => kAseqModelToolIdSet.has(x.id))
+const kSupportedSubModuleMap = new Map(kSupportedTools.map((x) => [
+		x.id,
+		{
+			dependencies: x.dependencies,
+			description: x.description,
+		},
+	]))
 
 module.exports =
 class AseqCompute extends PerGenomePipelineModule {


### PR DESCRIPTION
### Work done
It is useful to have submodules depend on other submodules. For example, predicting signal transduction proteins depends only on Aseq computed properties which are all implemented as submodules. This PR expands the pipeline logic to support such capabilities.

No new submodules are implemented here, but will be forthcoming and build upon this work.

### Tests
- [x] Existing modules run as expected
  