### PR TITLE
Pipeline module query data; filter SeedNewGenomes with query

### DIFF
--- a/mist-pipeline/src/lib/AbstractPipelineModule.js
+++ b/mist-pipeline/src/lib/AbstractPipelineModule.js
@@ -8,6 +8,7 @@ class AbstractPipelineModule {
 	constructor(app) {
 		this.config_ = app.config
 		this.logger_ = app.logger
+		this.query_ = (app.query || '').trim()
 		this.models_ = app.models
 		this.sequelize_ = app.sequelize
 		this.worker_ = app.worker


### PR DESCRIPTION
### Work done
Added ability to send arbitrary data to pipeline modules via the `query` command line argument. Extended the `SeedNewGenomes` module to only seed those genomes that match a regular expression passed in via `query` (if defined).

Examples:
1. Insert only those genomes that have `coli` in its name:
```
$ ./bin/pipeline.sh -q coli SeedNewGenomes
```

1. Insert all genomes that begin with Escher:
```
$ ./bin/pipeline.sh -q "^Escher" SeedNewGenomes
```

### Tests
- [ ] Run the SeedNewGenomes module without any query argument and confirm the previous behavior works as expected
- [ ] Run the SeedNewGenomes with a few queries and confirm that the appropriate genomes are seeded into the database