### PR TITLE
Support tool runners fetching additional aseq columns

### DIFF
--- a/mist-pipeline/src/lib/services/AseqsComputeService/index.js
+++ b/mist-pipeline/src/lib/services/AseqsComputeService/index.js
@@ -11,8 +11,8 @@ const Promise = require('bluebird')
 const AseqsService = require('mist-lib/services/AseqsService')
 
 // Other
-const kToolRunners = discoverToolRunners(),
-	kToolRunnerIdMap = new Map(kToolRunners.map((x) => [x.id, x]))
+const kToolRunners = discoverToolRunners()
+const kToolRunnerIdMap = new Map(kToolRunners.map((x) => [x.id, x]))
 
 module.exports =
 class AseqsComputeService extends AseqsService {
@@ -20,10 +20,30 @@ class AseqsComputeService extends AseqsService {
 		return kToolRunners
 	}
 
+	static toolRunnerIdMap() {
+		return kToolRunnerIdMap
+	}
+
 	constructor(model, config, logger) {
 		super(model, logger)
 
 		this.config_ = config
+	}
+
+	targetAseqFields(toolIds) {
+		const aseqFields = new Set()
+
+		toolIds
+			.map((toolId) => AseqsComputeService.toolRunnerIdMap().get(toolId))
+			.filter((meta) => !!meta)
+			.map((meta) => meta.requiredAseqFields || [])
+			.forEach((toolAseqFields) => {
+				toolAseqFields.forEach((toolAseqField) => {
+					aseqFields.add(toolAseqField)
+				})
+			})
+
+		return Array.from(aseqFields)
 	}
 
 	/**

--- a/mist-pipeline/src/lib/services/AseqsComputeService/tool-runners/AbstractToolRunner.js
+++ b/mist-pipeline/src/lib/services/AseqsComputeService/tool-runners/AbstractToolRunner.js
@@ -139,7 +139,8 @@ class AbstractToolRunner extends EventEmitter {
  * Template metadata to follow when describing this tool runner.
  */
 module.exports.meta = {
-	id: null,			// Unique string identifying this tool
-	dependencies: [],
+	id: null,						// Unique string identifying this tool
+	dependencies: [],		// Flat module id
 	description: null,
+	requiredAseqFields: [],	// Extra fields that should be fetched when retrieving Aseqs
 }

--- a/mist-pipeline/src/modules/per-genome/AseqCompute.js
+++ b/mist-pipeline/src/modules/per-genome/AseqCompute.js
@@ -100,12 +100,13 @@ class AseqCompute extends PerGenomePipelineModule {
 	aseqsMissingData_(toolIds, optTransaction) {
 		assert(toolIds && Array.isArray(toolIds) && toolIds.length > 0)
 
-		let {Component, Gene, Aseq} = this.models_,
-			toolSelectFields = toolIds.map((x) => `case when ${x} is not null then 1 else null end`)
-				.join(', '),
-			anyToolNullClause = toolIds.map((x) => x + ' is null').join(' OR '),
-			sql = `
-SELECT c.id, c.sequence, ${toolSelectFields}
+		const {Component, Gene, Aseq} = this.models_
+		const targetAseqFields = this.aseqsService_.targetAseqFields(toolIds)
+		const otherAseqFields = targetAseqFields.length ? ', ' + targetAseqFields.join(', ') : ''
+		const toolSelectFields = toolIds.map((x) => `case when ${x} is not null then 1 else null end`).join(', ')
+		const anyToolNullClause = toolIds.map((x) => x + ' is null').join(' OR ')
+		const sql = `
+SELECT c.id, c.sequence, ${toolSelectFields} ${otherAseqFields}
 FROM ${Component.getTableName()} a JOIN ${Gene.getTableName()} b ON (a.id = b.component_id)
 	JOIN ${Aseq.getTableName()} c ON (b.aseq_id = c.id)
 WHERE a.genome_id = ? AND b.aseq_id is not null and (${anyToolNullClause})


### PR DESCRIPTION
### Work done
When analyzing an aseq it is quite possible that the tool relies on additional data already computed for that aseq. For example, to predict signal transduction proteins, we need the pfam, agfam, and ecf domain predictions. Presently, the mist pipeline only fetches the id and sequence for each aseq when supplying data to a given tool runner. This PR adds the ability for tool runners to specify additional needed data fields to fetch from the database before executing the tool runner.

When creating a new tool runner, simply define a `requiredAseqFields` in it's exported meta object:

```
module.exports.meta = {
  id: 'stp',
  dependencies: ['AseqCompute:pfam30', 'AseqCompute:agfam2', 'AseqCompute:ecf1'],
  description: 'predict signal transduction proteins',
  requiredAseqFields: ['pfam30', 'agfam2', 'ecf1'],
}
```

The STP module has yet to be implemented, but will follow the above pattern. This work supports that forthcoming module.

### Tests
- [ ] Run pipeline with existing modules and confirm it behaves as expected