### PR TITLE
NCBICoreData module fixes

### DIFF
--- a/mist-lib/src/services/IdService.js
+++ b/mist-lib/src/services/IdService.js
@@ -28,7 +28,7 @@ class IdService {
 	 */
 	assignIds(records, model) {
 		if (!records.length)
-			return new Map()
+			return Promise.resolve(new Map())
 
 		return this.reserve(model.$idSequence(), records.length)
 		.then((idRange) => {

--- a/mist-pipeline/src/modules/per-genome/NCBICoreData/NCBIDataHelper.js
+++ b/mist-pipeline/src/modules/per-genome/NCBICoreData/NCBIDataHelper.js
@@ -88,8 +88,9 @@ class NCBIDataHelper {
 			if (!fileExists)
 				return false
 
-			let fileName = this.fileMapper_.localFileNameFor(sourceType),
-				checksum = this.checksums_[fileName]
+			const fileName = this.fileMapper_.localFileNameFor(sourceType)
+			const ncbiFileName = this.fileMapper_.ncbiFileNameFor(sourceType)
+			const checksum = this.checksums_[ncbiFileName]
 			if (checksum) {
 				this.logger_.info({fileName}, `Verifying ${sourceType} file contents`)
 				return mutil.checkFileMD5(destFile, checksum)


### PR DESCRIPTION
Fixes:
1. `IdService::assignIds` did not return a promise if there were no records
1. Now checks for the right file name when verifying file contents