### PR TITLE
Logic to calculate signal transduction profile and API route

### DIFF
--- a/mist-api/config/index.js
+++ b/mist-api/config/index.js
@@ -57,7 +57,12 @@ let config = {
 		version: 'X-' + packageJSON.name + '-version'
 	},
 
-	package: packageJSON
+	package: packageJSON,
+
+	signalTransduction: {
+		// Version of st analysis results to return to user
+		version: 1,
+	}
 }
 
 loadConfig(__dirname, config)

--- a/mist-api/src/routes/genomes/$accession/^exists/all.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/all.js
@@ -12,6 +12,6 @@ module.exports = function(app, middlewares) {
     queryAttribute: 'version',
     paramName: 'accession',
     targetName: 'genome',
-    attributes: ['id'] // Only return the genome id field, which we use in middleware #3
+    attributes: ['id'] // Only return the genome id field
   })
 }

--- a/mist-api/src/routes/genomes/$accession/^exists/all.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/all.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = function(app, middlewares) {
+  const models = app.get('models')
+
+  // Ensure that the genome identified by the query parameter ${accession} exists. Note
+  // that although the query parameter is labelled 'accession', the search is really done
+  // against the genome version (accession plus its version number). The following
+  // middlewares are not executed if this genome is not found. If it is found, the genome
+  // will be available on res.locals.genome (by virtue of setting 'genome' for targetName)
+	return middlewares.exists(models.Genome, {
+    queryAttribute: 'version',
+    paramName: 'accession',
+    targetName: 'genome',
+    attributes: ['id'] // Only return the genome id field, which we use in middleware #3
+  })
+}

--- a/mist-api/src/routes/genomes/$accession/^exists/genes/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/genes/get.js
@@ -9,19 +9,7 @@ module.exports = function(app, middlewares, routeMiddlewares) {
 	 * Series of middleware functions that limit returning all genes for a particular genome.
 	 */
 	return [
-		// 1. Ensure that the genome identified by the query parameter ${accession} exists. Note
-		//    that although the query parameter is labelled 'accession', the search is really done
-		//    against the genome version (accession plus its version number). The following
-		//    middlewares are not executed if this genome is not found. If it is found, the genome
-		//    will be available on res.locals.genome (by virtue of setting 'genome' for targetName)
-		middlewares.exists(models.Genome, {
-			queryAttribute: 'version',
-			paramName: 'accession',
-			targetName: 'genome',
-			attributes: ['id'] // Only return the genome id field, which we use in middleware #3
-		}),
-
-		// 2. Parse the criteria - same old, same old here
+		// 1. Parse the criteria - same old, same old here
 		middlewares.parseCriteriaForMany(models.Gene, {
 			accessibleModels: [
 				models.Aseq,
@@ -31,7 +19,7 @@ module.exports = function(app, middlewares, routeMiddlewares) {
 			permittedOrderFields: '*'
 		}),
 
-		// 3. Now the tricky part. Our goal is to limit all genes to those associated with the
+		// 2. Now the tricky part. Our goal is to limit all genes to those associated with the
 		//    genome identified in the exists middleware above. Thus, it is necessary to inner join
 		//    the genes table to the components table (vs Sequelize's default left join) and
 		//    specify the genome_id found earlier. This is accomplished by adding the Component
@@ -53,7 +41,7 @@ module.exports = function(app, middlewares, routeMiddlewares) {
 			next()
 		},
 
-		// 4. Pass control to the default find handler which processes applies the
+		// 3. Pass control to the default find handler which processes applies the
 		//    res.locals.criteria to the primary model defined in the RouteHelper.
 		helper.findManyHandler()
 	]

--- a/mist-api/src/routes/genomes/$accession/^exists/signal_genes/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/signal_genes/get.js
@@ -1,0 +1,52 @@
+'use strict'
+
+module.exports = function(app, middlewares, routeMiddlewares) {
+	const models = app.get('models')
+  const helper = app.get('lib').RouteHelper.for(models.SignalGene)
+
+  return [
+    middlewares.parseCriteriaForMany(models.SignalGene, {
+      accessibleModels: [
+        models.Gene,
+      ],
+      maxPage: null,
+      permittedOrderFields: '*',
+      permittedWhereFields: [
+        'id',
+        'gene_id',
+        'component_id',
+      ],
+    }),
+    (req, res, next) => {
+			res.locals.criteria.include.push({
+				model: models.Component,
+				attributes: ['name', 'version'],
+				where: {
+					genome_id: res.locals.genome.id
+				},
+				required: true
+			})
+      next()
+    },
+    helper.findManyHandler()
+  ]
+}
+
+module.exports.docs = function(modelExamples) {
+	return {
+		name: 'Fetch Member Signal Genes',
+		description: 'Returns an array of <a href="#signal-gene-model">Signal Genes</a> that belong to the genome identified by ${accession}.',
+		example: {
+			request: {
+				parameters: {
+					accession: modelExamples.Genome.version
+				}
+			},
+			response: {
+				body: [
+					modelExamples.SignalGene
+				]
+			}
+		}
+	}
+}

--- a/mist-api/src/routes/genomes/$accession/^exists/st-profile/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/st-profile/get.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = function(app, middlewares, routeMiddlewares) {
+  const { signalTransduction } = app.get('services')
+
+  return [
+    (req, res, next) => {
+      signalTransduction.domainProfile(res.locals.genome.id)
+      .then((domainProfile) => {
+        res.json(domainProfile)
+      })
+      .catch(next)
+    },
+  ]
+}

--- a/mist-api/src/routes/signal_domains/get.js
+++ b/mist-api/src/routes/signal_domains/get.js
@@ -1,0 +1,47 @@
+'use strict'
+
+module.exports = function(app, middlewares, routeMiddlewares) {
+	const models = app.get('models')
+  const helper = app.get('lib').RouteHelper.for(models.SignalDomain)
+
+  return [
+		middlewares.parseCriteriaForMany(
+      models.SignalDomain,
+      {
+        accessibleModels: [
+          models.SignalDomainMember,
+        ],
+         // A big enough amount such that all are may be returned with one request
+        defaultPerPage: 2500,
+        maxPage: null,
+        maxPerPage: 2500,
+        permittedOrderFields: '*',
+        permittedWhereFields: [
+          'name',
+          'version',
+          'kind',
+          'function',
+        ],
+      },
+    ),
+		helper.findManyHandler()
+  ]
+}
+
+module.exports.docs = function(modelExamples) {
+	return {
+		name: 'Fetch Many Signal Domains',
+		description: 'Returns an array of <a href="#signal-domain-model">Signal Domains</a>.',
+		method: null,
+		uri: null,
+		parameters: null,
+		example: {
+			response: {
+				body: [
+					modelExamples.SignalDomain
+				]
+			}
+		},
+		har: null
+	}
+}

--- a/mist-api/src/services.js
+++ b/mist-api/src/services.js
@@ -7,6 +7,7 @@ const path = require('path')
 const AnalyticsService = require('mist-lib/services/AnalyticsService')
 const CriteriaService = require('lib/services/CriteriaService')
 const TaxonomyService = require('mist-lib/services/TaxonomyService')
+const SignalTransductionService = require('mist-lib/services/SignalTransductionService')
 
 module.exports = function(app) {
 	const logger = app.get('logger')
@@ -19,6 +20,7 @@ module.exports = function(app) {
 			beaconImageFile: path.resolve(__dirname, '..', 'assets', 'img', 'beacon.gif')
 		}),
 		criteria: new CriteriaService(models),
+		signalTransduction: new SignalTransductionService(models, config.signalTransduction.version),
 		taxonomy: new TaxonomyService(models.Taxonomy, logger)
 	}
 }

--- a/mist-lib/src/services/SignalTransductionService.js
+++ b/mist-lib/src/services/SignalTransductionService.js
@@ -1,0 +1,150 @@
+'use strict'
+
+// Core
+const assert = require('assert')
+
+// Vendor
+const { sortBy } = require('lodash')
+
+module.exports =
+class SignalTransductionService {
+  constructor(models, version) {
+    assert(/^[1-9]\d*$/.test(version), 'Cannot instantiate SignalTransductionService without a valid version')
+
+    this.models_ = models
+    this.version_ = version
+    this.inputOutputCategories_ = null
+    this.signalDomainMap_ = this.createSignalDomainMap_(this.version_)
+      .then((signalDomainMap) => {
+        this.inputOutputCategories_ = this.getDistinctInputOutputCategories_(signalDomainMap)
+        return signalDomainMap
+      })
+  }
+
+  domainProfile(genomeId) {
+    return Promise.all([this.signalDomainMap_, this.fetchSignalGenesForGenome(genomeId, ['counts'])])
+      .then((values) => {
+        const [signalDomainMap, signalGenes] = values
+        return this.tallyDomainProfile(signalDomainMap, signalGenes)
+      })
+  }
+
+  fetchSignalGenesForGenome(genomeId, attributes) {
+    return this.models_.SignalGene.findAll({
+      attributes,
+      include: {
+        model: this.models_.Component,
+        attributes: [],
+        where: {
+          genome_id: genomeId,
+        },
+        required: true,
+      },
+    })
+  }
+
+  tallyDomainProfile(signalDomainMap, signalGenes) {
+    const lookupMap = new Map()
+    signalGenes.forEach((signalGene) => {
+      for (const [name, amount] of Object.entries(signalGene.counts)) {
+        const signalDomain = signalDomainMap.get(name)
+        if (!signalDomain) {
+          continue
+        }
+
+        const { kind } = signalDomain
+        // Only break out by function for input and output signal domains
+        const isInputOrOutput = kind === 'input' || kind === 'output'
+        const effectiveFunction = isInputOrOutput ? signalDomain.function : kind
+        const key = isInputOrOutput ? kind + '.' + effectiveFunction : kind
+        let group = lookupMap.get(key)
+        if (!group) {
+          group = {
+            kind,
+            function: effectiveFunction,
+            numDomains: 0,
+          }
+          lookupMap.set(key, group)
+        }
+        group.numDomains += amount
+      }
+    })
+
+    const takeGroupOrUseDefault = (key) => {
+      let group = lookupMap.get(key)
+      lookupMap.delete(key)
+      if (!group)
+        group = {kind: key, function: key, numDomains: 0}
+      return group
+    }
+
+    const inputsOutputs = () => {
+      return this.inputOutputCategories_
+        .map((category) => {
+          const key = category.kind + '.' + category.function
+          return lookupMap.get(key) || {kind: category.kind, function: category.function, numDomains: 0}
+        })
+    }
+
+    const ecf = takeGroupOrUseDefault('ecf')
+    const unknown = takeGroupOrUseDefault('unknown')
+
+    return [
+      takeGroupOrUseDefault('chemotaxis'),
+      takeGroupOrUseDefault('receiver'),
+      takeGroupOrUseDefault('transmitter'),
+      ...inputsOutputs(),
+      ecf,
+      unknown,
+    ]
+  }
+
+  // ------------------------------------------------------
+  // Private methods
+  createSignalDomainMap_(version) {
+    return this.models_.SignalDomain.findAll({
+      attributes: [
+        'name',
+        'kind',
+        'function',
+      ],
+      where: {
+        version,
+      },
+    })
+    .then((rows) => {
+      const result = new Map()
+      rows.forEach((row) => {
+        result.set(row.name, {kind: row.kind, function: row.function})
+      })
+      return result
+    })
+  }
+
+  getDistinctInputOutputCategories_(signalDomainMap) {
+    const makeKey = (signalDomain) => {
+      return signalDomain.kind + '.' + signalDomain.function
+    }
+
+    const seen = new Set()
+    const result = []
+    Array.from(signalDomainMap.values())
+      .filter((signalDomain) => signalDomain.kind === 'input' || signalDomain.kind === 'output')
+      .forEach((signalDomain) => {
+        const key = makeKey(signalDomain)
+        if (seen.has(key))
+          return
+
+        seen.add(key)
+        result.push({
+          kind: signalDomain.kind,
+          function: signalDomain.function,
+        })
+      })
+
+    return sortBy(result, [
+      (category) => category.kind,
+      (category) => category.function,
+    ])
+  }
+}

--- a/mist-lib/src/services/SignalTransductionService.js
+++ b/mist-lib/src/services/SignalTransductionService.js
@@ -91,8 +91,8 @@ class SignalTransductionService {
 
     return [
       takeGroupOrUseDefault('chemotaxis'),
-      takeGroupOrUseDefault('receiver'),
       takeGroupOrUseDefault('transmitter'),
+      takeGroupOrUseDefault('receiver'),
       ...inputsOutputs(),
       ecf,
       unknown,


### PR DESCRIPTION
For a given genome, exposes the route `/genomes/:stable_id/st-profile` to return the predicted signal transduction profile (based on signal domain counts - not protein counts). Specifically, the profile data returned is an array of objects that look like the following:

```bash
[
  {
    kind: 'chemotaxis',
    function: 'chemotaxis',
    numDomains: 3,
  },
  {
    ..
  }
]
```

Only input and output `kind`s are further subdivided by `function` for greater resolution. The other domain count `kinds` are aggregated into a single sum with their `function` set to their cognate `kind`.