### PR TITLE
Page 'count' parameter can be provided in request body now: 

### DIFF
--- a/mist-api/src/lib/RouteHelper.js
+++ b/mist-api/src/lib/RouteHelper.js
@@ -45,12 +45,13 @@ class RouteHelper {
 	 * - Partial fields
 	 * - Nested record fields
 	 * - Total count respecting conditions
-	 *
+	 * - inputGetter is an optional function which returns request query or body
 	 * @returns {Function} - express compatible handler function
 	 */
-	findManyHandler() {
+	findManyHandler(inputGetter = null) {
 		return (req, res, next) => {
-			const countRows = Reflect.has(req.query, 'count')
+			const input = inputGetter ? inputGetter(req) : req.query
+			const countRows = Reflect.has(input, 'count')
 			this.findAll_(res, countRows)
 			.then((entities) => {
 				res.append('Link', this.linkHeaders(req, res.locals.criteria.offset, res.locals.criteria.limit, res.locals.totalCount))

--- a/mist-api/src/routes/genes/genes-route-helpers.js
+++ b/mist-api/src/routes/genes/genes-route-helpers.js
@@ -32,7 +32,7 @@ exports.geneFinderMiddlewares = function(app, middlewares, inputGetter) {
 			}
 			next()
 		},
-		helper.findManyHandler()
+		helper.findManyHandler(inputGetter)
 	]
 }
 

--- a/mist-api/src/routes/genes/get.js
+++ b/mist-api/src/routes/genes/get.js
@@ -3,7 +3,7 @@
 const { geneFinderMiddlewares, docs } = require('./genes-route-helpers');
 
 module.exports = function(app, middlewares) {
-  return geneFinderMiddlewares(app, middlewares, (req) => { return req.query })
+  return geneFinderMiddlewares(app, middlewares, req => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genes/get.js
+++ b/mist-api/src/routes/genes/get.js
@@ -3,7 +3,7 @@
 const { geneFinderMiddlewares, docs } = require('./genes-route-helpers');
 
 module.exports = function(app, middlewares) {
-  return geneFinderMiddlewares(app, middlewares, req => req.query)
+  return geneFinderMiddlewares(app, middlewares, (req) => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genes/post.js
+++ b/mist-api/src/routes/genes/post.js
@@ -8,7 +8,7 @@ const { geneFinderMiddlewares, docs } = require('./genes-route-helpers');
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...geneFinderMiddlewares(app, middlewares, (req) => { return req.body })
+    ...geneFinderMiddlewares(app, middlewares, req => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genes/post.js
+++ b/mist-api/src/routes/genes/post.js
@@ -8,7 +8,7 @@ const { geneFinderMiddlewares, docs } = require('./genes-route-helpers');
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...geneFinderMiddlewares(app, middlewares, req => req.body)
+    ...geneFinderMiddlewares(app, middlewares, (req) => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genomes/$accession/^exists/genes/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/genes/get.js
@@ -3,7 +3,7 @@
 const { memberGenesFinderMiddlewares, docs } = require('./member-genes-route-helpers')
 
 module.exports = function(app, middlewares) {
-  return memberGenesFinderMiddlewares(app, middlewares, req => req.query)
+  return memberGenesFinderMiddlewares(app, middlewares, (req) => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genomes/$accession/^exists/genes/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/genes/get.js
@@ -3,7 +3,7 @@
 const { memberGenesFinderMiddlewares, docs } = require('./member-genes-route-helpers')
 
 module.exports = function(app, middlewares) {
-  return memberGenesFinderMiddlewares(app, middlewares, (req) => { return req.query })
+  return memberGenesFinderMiddlewares(app, middlewares, req => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genomes/$accession/^exists/genes/member-genes-route-helpers.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/genes/member-genes-route-helpers.js
@@ -63,7 +63,7 @@ exports.memberGenesFinderMiddlewares = function(app, middlewares, inputGetter) {
 
 		// 3. Pass control to the default find handler which processes applies the
 		//    res.locals.criteria to the primary model defined in the RouteHelper.
-		helper.findManyHandler()
+		helper.findManyHandler(inputGetter)
 	]
 }
 

--- a/mist-api/src/routes/genomes/$accession/^exists/genes/post.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/genes/post.js
@@ -8,7 +8,7 @@ const { memberGenesFinderMiddlewares, docs } = require('./member-genes-route-hel
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...memberGenesFinderMiddlewares(app, middlewares, (req) => { return req.body })
+    ...memberGenesFinderMiddlewares(app, middlewares, req => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genomes/$accession/^exists/genes/post.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/genes/post.js
@@ -8,7 +8,7 @@ const { memberGenesFinderMiddlewares, docs } = require('./member-genes-route-hel
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...memberGenesFinderMiddlewares(app, middlewares, req => req.body)
+    ...memberGenesFinderMiddlewares(app, middlewares, (req) => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genomes/$accession/^exists/signal-genes/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/signal-genes/get.js
@@ -3,7 +3,7 @@
 const { signalGeneFinderMiddlewares, docs } = require('./signal-genes-route-helpers')
 
 module.exports = function(app, middlewares) {
-  return signalGeneFinderMiddlewares(app, middlewares, req => req.query)
+  return signalGeneFinderMiddlewares(app, middlewares, (req) => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genomes/$accession/^exists/signal-genes/get.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/signal-genes/get.js
@@ -3,7 +3,7 @@
 const { signalGeneFinderMiddlewares, docs } = require('./signal-genes-route-helpers')
 
 module.exports = function(app, middlewares) {
-  return signalGeneFinderMiddlewares(app, middlewares, (req) => { return req.query })
+  return signalGeneFinderMiddlewares(app, middlewares, req => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genomes/$accession/^exists/signal-genes/post.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/signal-genes/post.js
@@ -8,7 +8,7 @@ const { signalGeneFinderMiddlewares, docs } = require('./signal-genes-route-help
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...signalGeneFinderMiddlewares(app, middlewares, (req) => { return req.body })
+    ...signalGeneFinderMiddlewares(app, middlewares, req => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genomes/$accession/^exists/signal-genes/post.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/signal-genes/post.js
@@ -8,7 +8,7 @@ const { signalGeneFinderMiddlewares, docs } = require('./signal-genes-route-help
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...signalGeneFinderMiddlewares(app, middlewares, req => req.body)
+    ...signalGeneFinderMiddlewares(app, middlewares, (req) => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genomes/$accession/^exists/signal-genes/signal-genes-route-helpers.js
+++ b/mist-api/src/routes/genomes/$accession/^exists/signal-genes/signal-genes-route-helpers.js
@@ -84,7 +84,7 @@ exports.signalGeneFinderMiddlewares = function(app, middlewares, inputGetter) {
 			})
 			.catch(next)
 		},
-		helper.findManyHandler()
+		helper.findManyHandler(inputGetter)
 	]
 }
 

--- a/mist-api/src/routes/genomes/genomes-route-helpers.js
+++ b/mist-api/src/routes/genomes/genomes-route-helpers.js
@@ -38,7 +38,7 @@ exports.genomeFinderMiddlewares = function(app, middlewares, inputGetter) {
             }
             next()
         },
-        helper.findManyHandler()
+        helper.findManyHandler(inputGetter)
     ]
 }
 

--- a/mist-api/src/routes/genomes/get.js
+++ b/mist-api/src/routes/genomes/get.js
@@ -3,7 +3,7 @@
 const { genomeFinderMiddlewares, docs } = require('./genomes-route-helpers')
 
 module.exports = function(app, middlewares) {
-  return genomeFinderMiddlewares(app, middlewares,  (req) => { return req.query })
+  return genomeFinderMiddlewares(app, middlewares, req => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genomes/get.js
+++ b/mist-api/src/routes/genomes/get.js
@@ -3,7 +3,7 @@
 const { genomeFinderMiddlewares, docs } = require('./genomes-route-helpers')
 
 module.exports = function(app, middlewares) {
-  return genomeFinderMiddlewares(app, middlewares, req => req.query)
+  return genomeFinderMiddlewares(app, middlewares, (req) => req.query)
 }
 
 module.exports.docs = docs

--- a/mist-api/src/routes/genomes/post.js
+++ b/mist-api/src/routes/genomes/post.js
@@ -8,7 +8,7 @@ const { genomeFinderMiddlewares, docs } = require('./genomes-route-helpers')
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...genomeFinderMiddlewares(app, middlewares, req => req.body)
+    ...genomeFinderMiddlewares(app, middlewares, (req) => req.body)
   ]
 }
 

--- a/mist-api/src/routes/genomes/post.js
+++ b/mist-api/src/routes/genomes/post.js
@@ -8,7 +8,7 @@ const { genomeFinderMiddlewares, docs } = require('./genomes-route-helpers')
 module.exports = function(app, middlewares) {
   return [
     bodyParser.urlencoded({extended: false}),
-    ...genomeFinderMiddlewares(app, middlewares, (req) => { return req.body })
+    ...genomeFinderMiddlewares(app, middlewares, req => req.body)
   ]
 }
 


### PR DESCRIPTION
added optional parameter, 'inputGetter', in findManyHandler(); Made more concise req input in get.js and post.js