### PR TITLE
Allow search for 'version's for POST calls in /genomes/

### DIFF
--- a/mist-api/src/routes/genomes/genomes-route-helpers.js
+++ b/mist-api/src/routes/genomes/genomes-route-helpers.js
@@ -27,7 +27,8 @@ exports.genomeFinderMiddlewares = function(app, middlewares, inputGetter) {
             ],
             permittedWhereFields: [
                 'id',
-                'taxonomy_id',
+				'taxonomy_id',
+				'version',
                 ...textFieldNames,
             ],
         }, inputGetter),


### PR DESCRIPTION
closes issue #75 

POST call to `/genomes/` accepts `where.version` and an array of genome version.