### PR TITLE
adds stable_ids to 'where' GET/POST in gene route

### DIFF
--- a/mist-api/src/routes/genes/genes-route-helpers.js
+++ b/mist-api/src/routes/genes/genes-route-helpers.js
@@ -23,6 +23,7 @@ exports.geneFinderMiddlewares = function(app, middlewares, inputGetter) {
 			],
 			permittedWhereFields: [
 				'id',
+				'stable_id'
 			],
 		}, inputGetter),
 		(req, res, next) => {


### PR DESCRIPTION
### Rationale
We already allow GET and POST from `where.id`. It will facilitate getting some genes by manually generated lists since `stable_id`s are human friendly.